### PR TITLE
Add project guidance and compile script for Java editing

### DIFF
--- a/.claude/hooks/compile-on-java-edit.sh
+++ b/.claude/hooks/compile-on-java-edit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Javaファイル編集後にMavenコンパイルを実行するhookスクリプト
+FILE=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
+
+if [ -z "$FILE" ]; then
+  exit 0
+fi
+
+if ! echo "$FILE" | grep -qE '[.]java$'; then
+  exit 0
+fi
+
+cd /Users/ak/Development/IdeaProjects/AssemblyBuilderForPC
+if bash mvnw compile -q 2>&1; then
+  printf '{"systemMessage": "compile OK"}\n'
+else
+  printf '{"systemMessage": "compile FAILED - check errors above"}\n'
+fi

--- a/.claude/hooks/compile-on-java-edit.sh
+++ b/.claude/hooks/compile-on-java-edit.sh
@@ -10,9 +10,24 @@ if ! echo "$FILE" | grep -qE '[.]java$'; then
   exit 0
 fi
 
-cd /Users/ak/Development/IdeaProjects/AssemblyBuilderForPC
-if bash mvnw compile -q 2>&1; then
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=${REPO_ROOT:-$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)}
+
+if [ -z "$REPO_ROOT" ]; then
+  REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+fi
+
+if ! cd "$REPO_ROOT"; then
+  printf '{"systemMessage": "compile FAILED - could not resolve repo root"}\n'
+  exit 1
+fi
+
+MAVEN_LOG=$(mktemp)
+trap 'rm -f "$MAVEN_LOG"' EXIT
+
+if bash mvnw compile -q >"$MAVEN_LOG" 2>&1; then
   printf '{"systemMessage": "compile OK"}\n'
 else
-  printf '{"systemMessage": "compile FAILED - check errors above"}\n'
+  cat "$MAVEN_LOG" >&2
+  printf '{"systemMessage": "compile FAILED - see stderr for Maven output"}\n'
 fi

--- a/.claude/hooks/compile-on-java-edit.sh
+++ b/.claude/hooks/compile-on-java-edit.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # Javaファイル編集後にMavenコンパイルを実行するhookスクリプト
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '{"systemMessage": "compile skipped - jq is not installed"}\n'
+  exit 0
+fi
+
 FILE=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
 
 if [ -z "$FILE" ]; then
@@ -27,7 +33,9 @@ trap 'rm -f "$MAVEN_LOG"' EXIT
 
 if bash mvnw compile -q >"$MAVEN_LOG" 2>&1; then
   printf '{"systemMessage": "compile OK"}\n'
+  exit 0
 else
   cat "$MAVEN_LOG" >&2
   printf '{"systemMessage": "compile FAILED - see stderr for Maven output"}\n'
+  exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+自作PC構成・総額シミュレーションWebアプリ（https://www.pcbuilding.link/）。
+Spring Boot + H2 + Thymeleaf構成。kakaku.comから価格データをスクレイピングし、Gemini AIによる構成レビュー機能を持つ。
+
+## Commands
+
+```bash
+# ビルド
+./mvnw package
+
+# テスト実行
+./mvnw test
+
+# 特定テストのみ実行
+./mvnw test -Dtest=ApiResponseControllerTest
+
+# ローカル起動（環境変数が必要）
+export SPRING_DATASOURCE_URL=jdbc:h2:file:./data/pcassem
+export SPRING_DATASOURCE_USERNAME=sa
+export SPRING_DATASOURCE_PASSWORD=password
+export GEMINI_API_KEY=your_key
+./mvnw spring-boot:run
+```
+
+## 必要な環境変数
+
+| 変数名 | 用途 |
+|--------|------|
+| `SPRING_DATASOURCE_URL` | H2 DB接続URL |
+| `SPRING_DATASOURCE_USERNAME` | DBユーザー名 |
+| `SPRING_DATASOURCE_PASSWORD` | DBパスワード |
+| `GEMINI_API_KEY` | Gemini AI API キー |
+
+本番環境ではAWS Systems Manager Parameter Storeから取得（`buildspec.yml`参照）。
+
+## Architecture
+
+### レイヤー構成
+
+```
+presentation/
+  controller/GeminiReviewController  - POST /api/gemini/review
+  data/ReviewRequest|Response|...    - リクエスト/レスポンスDTO
+HomeController                       - MVC: 全ページルーティング + アセンブリ管理
+ApiResponseController                - REST: GET /api/devicelist, /api/update
+DeviceInfoDao                        - JdbcTemplate によるデータアクセス
+KakakuClient                        - kakaku.com スクレイピング
+domain/gemini/GeminiServiceImpl      - Gemini API呼び出し（gemini-2.5-flash）
+```
+
+### データフロー
+
+1. **価格データ更新**: 起動時 + 毎日4:00 AMにTimerTaskで`KakakuClient`がkakaku.comをスクレイピング → `devices`テーブルに格納
+   - 週1回フルスキャン（165時間ごと）、それ以外は差分更新
+2. **ページ表示**: `HomeController`が`DeviceInfoDao`からパーツ一覧を取得 → Thymeleaf `index.html`へ
+3. **構成管理**: ゲストID（32文字UUID、クライアント保持）で`assemblies`テーブルに紐付け
+4. **保存/共有**: `/save` POST → `savehead`+`savelist`に保存 → `/rec/{32文字ID}` でURL共有
+
+### DBスキーマ（H2）
+
+- `devices` - パーツカタログ（`device`カラムでパーツ種別を区別）
+- `assemblies` - ユーザーの選択パーツ（guestidで紐付け）
+- `savehead` / `savelist` - 保存済み構成（saveIDがそのまま公開URLになる）
+- `systemvals` - 最終価格更新日時
+
+### 重要な設計上の注意点
+
+- **ユーザー認証なし**: ゲストIDによる識別のみ。`guestId.length() == 32` でバリデーション
+- **`index.html`単一テンプレート**: 全ページを`index.html`で表示し、Thymeleafの`th:if`で表示切替
+- **パーツ種別**: `deviceTypeList`に定義された19種類の英語キー（`pccase`, `motherboard`等）で管理。日本語名は`deviceTypeJp`マップで変換
+- **`HomeController`内のinner records**: `DeviceInfo`, `UserAssem`, `SaveHead`等のデータクラスがHomeControllerのinner recordsとして定義されており、`DeviceInfoDao`からも参照される
+
+### デプロイ
+
+AWS CodeBuild（`buildspec.yml`）→ S3 → CodeDeploy（`appspec.yml` + `update.sh`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ domain/gemini/GeminiServiceImpl      - Gemini API呼び出し（gemini-2.5-flash
 ### 重要な設計上の注意点
 
 - **ユーザー認証なし**: ゲストIDによる識別のみ。`guestId.length() == 32` でバリデーション
-- **`index.html`単一テンプレート**: 全ページを`index.html`で表示し、Thymeleafの`th:if`で表示切替
+- **`index.html`がメインテンプレート**: 多くのページは`index.html`を使い、Thymeleafの`th:if`で表示切替するが、`/policy_ja`や`/policy_en`など一部ルートは専用テンプレートを返す
 - **パーツ種別**: `deviceTypeList`に定義された19種類の英語キー（`pccase`, `motherboard`等）で管理。日本語名は`deviceTypeJp`マップで変換
 - **`HomeController`内のinner records**: `DeviceInfo`, `UserAssem`, `SaveHead`等のデータクラスがHomeControllerのinner recordsとして定義されており、`DeviceInfoDao`からも参照される
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,10 @@ Spring Boot + H2 + Thymeleaf構成。kakaku.comから価格データをスクレ
 ./mvnw test -Dtest=ApiResponseControllerTest
 
 # ローカル起動（環境変数が必要）
-export SPRING_DATASOURCE_URL=jdbc:h2:file:./data/pcassem
-export SPRING_DATASOURCE_USERNAME=sa
-export SPRING_DATASOURCE_PASSWORD=password
-export GEMINI_API_KEY=your_key
+export SPRING_DATASOURCE_URL=your_datasource_url_here
+export SPRING_DATASOURCE_USERNAME=your_db_username_here
+export SPRING_DATASOURCE_PASSWORD=your_db_password_here
+export GEMINI_API_KEY=your_gemini_api_key_here
 ./mvnw spring-boot:run
 ```
 


### PR DESCRIPTION
This pull request adds important developer tooling and documentation to the project. It introduces a new guidance file for Claude Code and a shell hook to automatically compile Java files after editing. These enhancements aim to improve the developer experience and streamline the workflow.

**Developer documentation:**

* Added `CLAUDE.md` to provide project overview, build/test instructions, required environment variables, architecture, data flow, DB schema, and deployment notes for Claude Code and developers.

**Developer tooling:**

* Added `.claude/hooks/compile-on-java-edit.sh`, a shell hook that triggers Maven compilation automatically after editing Java files, providing immediate feedback on compilation status.