### PR TITLE
fix: remove hardcoded DOMAIN_NAME constant from HomeController

### DIFF
--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -38,8 +38,6 @@ import java.util.UUID;
 
 @Controller
 public class HomeController {
-    public static final String DOMAIN_NAME = "https://www.pcbuilding.link/"; // server env.
-
     public static final boolean DEBUG = false;
     private static final Logger logger = LoggerFactory.getLogger(HomeController.class);
     public static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd H:mm");
@@ -158,7 +156,7 @@ public class HomeController {
 
     record SaveHeader (String url, String text) {
         static SaveHeader create(SaveHead sh, int index) {
-            return new SaveHeader(DOMAIN_NAME+"rec/"+ sh.saveid(), CIRCLE_INDEX_5[index]);
+            return new SaveHeader("/rec/"+ sh.saveid(), CIRCLE_INDEX_5[index]);
         }
     }
     static final String[] CIRCLE_INDEX_5 = {"①", "②", "③", "④", "⑤"};


### PR DESCRIPTION
## Summary
- `HomeController`からハードコードされた`DOMAIN_NAME`定数を削除
- `SaveHeader.create()`内のリンク生成を絶対URLから相対パス(`/rec/{saveid}`)に変更

## 背景
`DOMAIN_NAME`に本番ドメインが直接指定されていたため、テスト環境・ローカル環境でも本番URLにリダイレクトされてしまう問題に対応。

Closes #12

https://claude.ai/code/session_018xUkHvhyAsrNgWJ47bxfQ1