### PR TITLE
Fix migration firebase

### DIFF
--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -577,18 +577,19 @@ public class HomeController {
 
         List<RestoreDevice> rdList = null;
 
-        // Firestore から取得を試みる
+        // Firestore から取得を試みる（null = ドキュメントなし、非null = ドキュメントあり）
         try {
             List<DeviceInfoDao.SaveItem> saveItems = firestoreService.getSaveItems(saveId);
-            if (saveItems != null && !saveItems.isEmpty()) {
+            if (saveItems != null) {
+                // ドキュメントが存在する場合はその結果を使う（空リストでも H2 にフォールバックしない）
                 rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems);
             }
         } catch (Exception e) {
             logger.error("[HomeController] Failed to get save from Firestore: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
         }
 
-        // Firestore になければ H2 から取得
-        if (rdList == null || rdList.isEmpty()) {
+        // Firestore にドキュメントが存在しない場合のみ H2 から取得
+        if (rdList == null) {
             rdList = dao.restore(saveId);
         }
 

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -583,7 +583,7 @@ public class HomeController {
         try {
             Optional<List<DeviceInfoDao.SaveItem>> saveItems = firestoreService.getSaveItems(saveId);
             if (saveItems.isPresent()) {
-                // ドキュメントが存在する場合はその結果を使う（空リストでも H2 にフォールバックしない）
+                // ドキュメントと items フィールドが存在する場合はその結果を使う（空リストでも H2 にフォールバックしない）
                 rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems.get());
             }
         } catch (Exception e) {
@@ -591,7 +591,7 @@ public class HomeController {
             firestoreError = true;
         }
 
-        // Firestore にドキュメントが存在しない場合のみ H2 から取得
+        // Firestore にドキュメントが存在しない、または items フィールドが存在しない場合のみ H2 から取得
         if (rdList == null) {
             rdList = dao.restore(saveId);
         }

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Timer;
 import java.util.stream.Collectors;
@@ -577,12 +578,12 @@ public class HomeController {
 
         List<RestoreDevice> rdList = null;
 
-        // Firestore から取得を試みる（null = ドキュメントなし、非null = ドキュメントあり）
+        // Firestore から取得を試みる（empty = ドキュメントなし、present = ドキュメントあり）
         try {
-            List<DeviceInfoDao.SaveItem> saveItems = firestoreService.getSaveItems(saveId);
-            if (saveItems != null) {
+            Optional<List<DeviceInfoDao.SaveItem>> saveItems = firestoreService.getSaveItems(saveId);
+            if (saveItems.isPresent()) {
                 // ドキュメントが存在する場合はその結果を使う（空リストでも H2 にフォールバックしない）
-                rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems);
+                rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems.get());
             }
         } catch (Exception e) {
             logger.error("[HomeController] Failed to get save from Firestore: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
@@ -608,7 +609,11 @@ public class HomeController {
     }
 
     private List<RestoreDevice> buildRestoreDevicesFromSaveItems(String saveId, List<DeviceInfoDao.SaveItem> saveItems) {
-        List<String> deviceIds = saveItems.stream().map(DeviceInfoDao.SaveItem::deviceId).toList();
+        List<String> deviceIds = saveItems.stream()
+                .map(DeviceInfoDao.SaveItem::deviceId)
+                .filter(id -> id != null && !id.isBlank())
+                .distinct()
+                .toList();
         Map<String, DeviceInfo> deviceMap = dao.findRecordByIds(deviceIds).stream()
                 .collect(Collectors.toMap(DeviceInfo::id, d -> d));
         return saveItems.stream()

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -10,6 +10,7 @@ import jp.developer.bbee.pcassem.model.UserAssem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 
 import org.springframework.ui.Model;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.IOException;
@@ -33,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
+import java.util.stream.Collectors;
 import java.util.TimerTask;
 import java.util.UUID;
 
@@ -571,8 +574,29 @@ public class HomeController {
     @GetMapping("/rec/{saveId:[0-9a-fA-F]{32}}")
     String restoreConstruction(Model model, @PathVariable String saveId) {
         saveId = saveId.toLowerCase();
-        System.out.println(saveId);
-        List<RestoreDevice> rdList = dao.restore(saveId);
+
+        List<RestoreDevice> rdList = null;
+
+        // Firestore から取得を試みる
+        try {
+            List<DeviceInfoDao.SaveItem> saveItems = firestoreService.getSaveItems(saveId);
+            if (saveItems != null && !saveItems.isEmpty()) {
+                rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems);
+            }
+        } catch (Exception e) {
+            logger.error("[HomeController] Failed to get save from Firestore: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
+        }
+
+        // Firestore になければ H2 から取得
+        if (rdList == null || rdList.isEmpty()) {
+            rdList = dao.restore(saveId);
+        }
+
+        // どちらにもなければ 404
+        if (rdList.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+
         List<RestoreDeviceFormatted> rdfList = rdList.stream().map(RestoreDeviceFormatted::create).toList();
         model.addAttribute("saveHeadVisible", "hidden");
         model.addAttribute("restoredList", rdfList);
@@ -580,5 +604,18 @@ public class HomeController {
         model.addAttribute("deviceListDisplay", "hidden");
         model.addAttribute("updateTime", dao.getTime().format(formatter));
         return "index";
+    }
+
+    private List<RestoreDevice> buildRestoreDevicesFromSaveItems(String saveId, List<DeviceInfoDao.SaveItem> saveItems) {
+        List<String> deviceIds = saveItems.stream().map(DeviceInfoDao.SaveItem::deviceId).toList();
+        Map<String, DeviceInfo> deviceMap = dao.findRecordByIds(deviceIds).stream()
+                .collect(Collectors.toMap(DeviceInfo::id, d -> d));
+        return saveItems.stream()
+                .filter(item -> deviceMap.containsKey(item.deviceId()))
+                .map(item -> {
+                    DeviceInfo di = deviceMap.get(item.deviceId());
+                    return new RestoreDevice(saveId, di.id(), di.device(), di.url(), di.name(),
+                            di.imgurl(), di.detail(), item.price(), di.price());
+                }).toList();
     }
 }

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -576,31 +576,25 @@ public class HomeController {
     String restoreConstruction(Model model, @PathVariable String saveId) {
         saveId = saveId.toLowerCase();
 
-        List<RestoreDevice> rdList = null;
-        boolean firestoreError = false;
-
-        // Firestore から取得を試みる（empty = ドキュメントなし、present = ドキュメントあり）
+        // Firestore から取得を試みる。例外時は即 503。
+        Optional<List<DeviceInfoDao.SaveItem>> saveItems;
         try {
-            Optional<List<DeviceInfoDao.SaveItem>> saveItems = firestoreService.getSaveItems(saveId);
-            if (saveItems.isPresent()) {
-                // ドキュメントが存在する場合はその結果を使う（items が空でも H2 にフォールバックしない）
-                rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems.get());
-            }
+            saveItems = firestoreService.getSaveItems(saveId);
         } catch (Exception e) {
             logger.error("[HomeController] Failed to get save from Firestore: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
-            firestoreError = true;
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
         }
 
-        // Firestore にドキュメントが存在しない場合のみ H2 から取得
-        if (rdList == null) {
+        // ドキュメントが存在する場合はその結果を使う（items が空でも H2 にフォールバックしない）
+        // ドキュメントが存在しない場合のみ H2 から取得
+        List<RestoreDevice> rdList;
+        if (saveItems.isPresent()) {
+            rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems.get());
+        } else {
             rdList = dao.restore(saveId);
         }
 
         if (rdList.isEmpty()) {
-            // Firestore 障害でデータが取得できなかった可能性がある場合は 503
-            if (firestoreError) {
-                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
-            }
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
 

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -583,7 +583,7 @@ public class HomeController {
         try {
             Optional<List<DeviceInfoDao.SaveItem>> saveItems = firestoreService.getSaveItems(saveId);
             if (saveItems.isPresent()) {
-                // ドキュメントと items フィールドが存在する場合はその結果を使う（空リストでも H2 にフォールバックしない）
+                // ドキュメントが存在する場合はその結果を使う（items が空でも H2 にフォールバックしない）
                 rdList = buildRestoreDevicesFromSaveItems(saveId, saveItems.get());
             }
         } catch (Exception e) {
@@ -591,7 +591,7 @@ public class HomeController {
             firestoreError = true;
         }
 
-        // Firestore にドキュメントが存在しない、または items フィールドが存在しない場合のみ H2 から取得
+        // Firestore にドキュメントが存在しない場合のみ H2 から取得
         if (rdList == null) {
             rdList = dao.restore(saveId);
         }

--- a/src/main/java/jp/developer/bbee/pcassem/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/HomeController.java
@@ -577,6 +577,7 @@ public class HomeController {
         saveId = saveId.toLowerCase();
 
         List<RestoreDevice> rdList = null;
+        boolean firestoreError = false;
 
         // Firestore から取得を試みる（empty = ドキュメントなし、present = ドキュメントあり）
         try {
@@ -587,6 +588,7 @@ public class HomeController {
             }
         } catch (Exception e) {
             logger.error("[HomeController] Failed to get save from Firestore: {} - {}", e.getClass().getSimpleName(), e.getMessage(), e);
+            firestoreError = true;
         }
 
         // Firestore にドキュメントが存在しない場合のみ H2 から取得
@@ -594,8 +596,11 @@ public class HomeController {
             rdList = dao.restore(saveId);
         }
 
-        // どちらにもなければ 404
         if (rdList.isEmpty()) {
+            // Firestore 障害でデータが取得できなかった可能性がある場合は 503
+            if (firestoreError) {
+                throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE);
+            }
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
 

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
@@ -15,4 +15,6 @@ public interface FirestoreService {
     List<SaveHead> getSaveHeadsRecent5(String firebaseUid) throws Exception;
     void addAssembly(String firebaseUid, UserAssem assem) throws Exception;
     void deleteAssembly(String firebaseUid, String deviceId) throws Exception;
+    /** saves/{saveId} の items を返す。ドキュメントが存在しない場合は null を返す。 */
+    List<SaveItem> getSaveItems(String saveId) throws Exception;
 }

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
@@ -16,6 +16,10 @@ public interface FirestoreService {
     List<SaveHead> getSaveHeadsRecent5(String firebaseUid) throws Exception;
     void addAssembly(String firebaseUid, UserAssem assem) throws Exception;
     void deleteAssembly(String firebaseUid, String deviceId) throws Exception;
-    /** saves/{saveId} の items を返す。ドキュメントが存在しない場合は Optional.empty()、存在する場合は Optional.of(items) を返す。 */
+    /**
+     * saves/{saveId} の items を返す。
+     * ドキュメントが存在しない、または items フィールドが存在しない場合は Optional.empty() を返す。
+     * ドキュメントが存在し items フィールドが存在する場合は Optional.of(items) を返す（空リストも含む）。
+     */
     Optional<List<SaveItem>> getSaveItems(String saveId) throws Exception;
 }

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
@@ -18,8 +18,8 @@ public interface FirestoreService {
     void deleteAssembly(String firebaseUid, String deviceId) throws Exception;
     /**
      * saves/{saveId} の items を返す。
-     * ドキュメントが存在しない、または items フィールドが存在しない場合は Optional.empty() を返す。
-     * ドキュメントが存在し items フィールドが存在する場合は Optional.of(items) を返す（空リストも含む）。
+     * ドキュメントが存在しない場合のみ Optional.empty() を返す（H2 フォールバック用）。
+     * ドキュメントが存在する場合は items の有無にかかわらず Optional.of(items) を返す（空リストを含む）。
      */
     Optional<List<SaveItem>> getSaveItems(String saveId) throws Exception;
 }

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.java
@@ -6,6 +6,7 @@ import jp.developer.bbee.pcassem.model.UserAssem;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface FirestoreService {
     void saveAssemblies(String firebaseUid, List<UserAssem> assemblies) throws Exception;
@@ -15,6 +16,6 @@ public interface FirestoreService {
     List<SaveHead> getSaveHeadsRecent5(String firebaseUid) throws Exception;
     void addAssembly(String firebaseUid, UserAssem assem) throws Exception;
     void deleteAssembly(String firebaseUid, String deviceId) throws Exception;
-    /** saves/{saveId} の items を返す。ドキュメントが存在しない場合は null を返す。 */
-    List<SaveItem> getSaveItems(String saveId) throws Exception;
+    /** saves/{saveId} の items を返す。ドキュメントが存在しない場合は Optional.empty()、存在する場合は Optional.of(items) を返す。 */
+    Optional<List<SaveItem>> getSaveItems(String saveId) throws Exception;
 }

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
@@ -142,8 +142,7 @@ public class FirestoreServiceImpl implements FirestoreService {
         if (!doc.exists()) return Optional.empty();
 
         List<Map<String, Object>> items = (List<Map<String, Object>>) doc.get("items");
-        if (items == null) return Optional.empty(); // フィールド未存在の古いドキュメントは H2 フォールバックへ
-        if (items.isEmpty()) return Optional.of(List.of());
+        if (items == null || items.isEmpty()) return Optional.of(List.of());
 
         return Optional.of(items.stream().map(item -> {
             String deviceId = (String) item.get("deviceId");

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
@@ -1,6 +1,7 @@
 package jp.developer.bbee.pcassem.domain.firestore;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.WriteBatch;
@@ -131,6 +132,30 @@ public class FirestoreServiceImpl implements FirestoreService {
                 .collection("assemblies")
                 .document(deviceId)
                 .delete().get();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<SaveItem> getSaveItems(String saveId) throws Exception {
+        DocumentSnapshot doc = firestore.collection("saves").document(saveId).get().get();
+        if (!doc.exists()) return null;
+
+        List<Map<String, Object>> items = (List<Map<String, Object>>) doc.get("items");
+        if (items == null || items.isEmpty()) return List.of();
+
+        return items.stream().map(item -> {
+            String deviceId = (String) item.get("deviceId");
+            int price = item.get("price") != null ? ((Number) item.get("price")).intValue() : 0;
+            Timestamp created = (Timestamp) item.get("createddate");
+            Timestamp updated = (Timestamp) item.get("lastupdate");
+            return new SaveItem(
+                    saveId,
+                    deviceId != null ? deviceId : "",
+                    price,
+                    created != null ? created.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime() : DateTimeConst.FALLBACK,
+                    updated != null ? updated.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime() : DateTimeConst.FALLBACK
+            );
+        }).toList();
     }
 
     @Override

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
@@ -142,7 +142,8 @@ public class FirestoreServiceImpl implements FirestoreService {
         if (!doc.exists()) return Optional.empty();
 
         List<Map<String, Object>> items = (List<Map<String, Object>>) doc.get("items");
-        if (items == null || items.isEmpty()) return Optional.of(List.of());
+        if (items == null) return Optional.empty(); // フィールド未存在の古いドキュメントは H2 フォールバックへ
+        if (items.isEmpty()) return Optional.of(List.of());
 
         return Optional.of(items.stream().map(item -> {
             String deviceId = (String) item.get("deviceId");

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class FirestoreServiceImpl implements FirestoreService {
@@ -136,14 +137,14 @@ public class FirestoreServiceImpl implements FirestoreService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<SaveItem> getSaveItems(String saveId) throws Exception {
+    public Optional<List<SaveItem>> getSaveItems(String saveId) throws Exception {
         DocumentSnapshot doc = firestore.collection("saves").document(saveId).get().get();
-        if (!doc.exists()) return null;
+        if (!doc.exists()) return Optional.empty();
 
         List<Map<String, Object>> items = (List<Map<String, Object>>) doc.get("items");
-        if (items == null || items.isEmpty()) return List.of();
+        if (items == null || items.isEmpty()) return Optional.of(List.of());
 
-        return items.stream().map(item -> {
+        return Optional.of(items.stream().map(item -> {
             String deviceId = (String) item.get("deviceId");
             int price = item.get("price") != null ? ((Number) item.get("price")).intValue() : 0;
             Timestamp created = (Timestamp) item.get("createddate");
@@ -155,7 +156,7 @@ public class FirestoreServiceImpl implements FirestoreService {
                     created != null ? created.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime() : DateTimeConst.FALLBACK,
                     updated != null ? updated.toDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime() : DateTimeConst.FALLBACK
             );
-        }).toList();
+        }).toList());
     }
 
     @Override

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
@@ -29,9 +29,9 @@ public class MigrationController {
             return ResponseEntity.badRequest()
                     .body(new MigrationResponse(false, "idToken is required"));
         }
-        if (request.guestId == null || request.guestId.length() != 32) {
+        if (request.guestId == null || !request.guestId.matches("[0-9a-fA-F]{32}")) {
             return ResponseEntity.badRequest()
-                    .body(new MigrationResponse(false, "guestId is required"));
+                    .body(new MigrationResponse(false, "guestId must be a 32-character hex string"));
         }
         try {
             boolean migrated = migrationService.migrate(request.idToken, request.guestId);

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
@@ -1,6 +1,5 @@
 package jp.developer.bbee.pcassem.presentation.controller;
 
-import javax.servlet.http.HttpSession;
 import jp.developer.bbee.pcassem.domain.migration.MigrationService;
 import jp.developer.bbee.pcassem.presentation.data.MigrationRequest;
 import jp.developer.bbee.pcassem.presentation.data.MigrationResponse;
@@ -25,18 +24,17 @@ public class MigrationController {
     }
 
     @PostMapping
-    public ResponseEntity<MigrationResponse> migrate(@RequestBody MigrationRequest request, HttpSession session) {
-        String guestId = (String) session.getAttribute("guestId");
-        if (guestId == null || guestId.length() != 32) {
-            return ResponseEntity.badRequest()
-                    .body(new MigrationResponse(false, "No valid session"));
-        }
+    public ResponseEntity<MigrationResponse> migrate(@RequestBody MigrationRequest request) {
         if (request.idToken == null || request.idToken.isBlank()) {
             return ResponseEntity.badRequest()
                     .body(new MigrationResponse(false, "idToken is required"));
         }
+        if (request.guestId == null || request.guestId.length() != 32) {
+            return ResponseEntity.badRequest()
+                    .body(new MigrationResponse(false, "guestId is required"));
+        }
         try {
-            boolean migrated = migrationService.migrate(request.idToken, guestId);
+            boolean migrated = migrationService.migrate(request.idToken, request.guestId);
             String message = migrated ? "Migration successful" : "Already migrated";
             return ResponseEntity.ok(new MigrationResponse(true, message));
         } catch (Exception e) {

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Locale;
+
 @RestController
 @RequestMapping("api/migrate")
 public class MigrationController {
@@ -42,7 +44,7 @@ public class MigrationController {
                     .body(new MigrationResponse(false, "guestId must be a 32-character hex string"));
         }
         try {
-            boolean migrated = migrationService.migrate(request.idToken, request.guestId.toLowerCase());
+            boolean migrated = migrationService.migrate(request.idToken, request.guestId.toLowerCase(Locale.ROOT));
             String message = migrated ? "Migration successful" : "Already migrated";
             return ResponseEntity.ok(new MigrationResponse(true, message));
         } catch (Exception e) {

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
@@ -6,6 +6,8 @@ import jp.developer.bbee.pcassem.presentation.data.MigrationResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,6 +23,12 @@ public class MigrationController {
 
     public MigrationController(MigrationService migrationService) {
         this.migrationService = migrationService;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<MigrationResponse> handleInvalidBody() {
+        return ResponseEntity.badRequest()
+                .body(new MigrationResponse(false, "Invalid request body"));
     }
 
     @PostMapping

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/MigrationController.java
@@ -42,7 +42,7 @@ public class MigrationController {
                     .body(new MigrationResponse(false, "guestId must be a 32-character hex string"));
         }
         try {
-            boolean migrated = migrationService.migrate(request.idToken, request.guestId);
+            boolean migrated = migrationService.migrate(request.idToken, request.guestId.toLowerCase());
             String message = migrated ? "Migration successful" : "Already migrated";
             return ResponseEntity.ok(new MigrationResponse(true, message));
         } catch (Exception e) {

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationRequest.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationRequest.java
@@ -1,5 +1,6 @@
 package jp.developer.bbee.pcassem.presentation.data;
 
 public class MigrationRequest {
-    public String idToken;  // Firebase IDトークン（クライアントから送信）
+    public String idToken;   // Firebase IDトークン（クライアントから送信）
+    public String guestId;   // 移行元の guestId（localStorage から送信）
 }

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -22,20 +22,20 @@ window.onload = function() {
 // Firebase Anonymous Auth - idToken を POST で送信してサーバーセッションを確立する（URLに露出させない）
 (async function initFirebaseAuth() {
   try {
-    // 同一タブ内で認証済みかつサーバーセッションが有効な場合はスキップ（リダイレクトループ防止）
-    // ただし移行未完了の guestId が残っている場合はスキップしない（5xx失敗後の再試行のため）
+    // 同一タブ内で認証済みの場合はサーバーセッションを確認する
     if (sessionStorage.getItem('auth_done') === 'true') {
       const existingGuestId = localStorage.getItem('guestid');
       const hasPendingMigration = existingGuestId
         && /^[0-9a-fA-F]{32}$/.test(existingGuestId)
         && localStorage.getItem('migration_completed') !== 'true';
-      if (!hasPendingMigration) {
-        const check = await fetch('/api/session', { credentials: 'same-origin' });
-        if (check.ok) return;
-        // サーバーセッションが失効していた場合は再認証する
+      const check = await fetch('/api/session', { credentials: 'same-origin' });
+      if (!hasPendingMigration && check.ok) return;
+      if (!check.ok) {
+        // セッション失効: 再認証後に isFirstAuthInTab=true となるよう両フラグをクリア
         sessionStorage.removeItem('auth_done');
         sessionStorage.removeItem('session_established');
       }
+      // hasPendingMigration=true かつ check.ok: セッションは有効だが移行未完了のため再認証して移行を実行
     }
 
     const res = await fetch('/api/firebase/config');
@@ -82,7 +82,7 @@ window.onload = function() {
               method: 'POST',
               credentials: 'same-origin',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ idToken: idToken, guestId: existingGuestId })
+              body: JSON.stringify({ idToken: idToken, guestId: existingGuestId.toLowerCase() })
             });
             if (migrateRes.ok) {
               const result = await migrateRes.json();

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -61,7 +61,7 @@ window.onload = function() {
 
         // 未移行の guestId があれば Firestore へ移行する
         const existingGuestId = localStorage.getItem('guestid');
-        if (existingGuestId && existingGuestId.length === 32
+        if (existingGuestId && /^[0-9a-fA-F]{32}$/.test(existingGuestId)
             && localStorage.getItem('migration_completed') !== 'true') {
           try {
             const migrateRes = await fetch('/api/migrate', {
@@ -77,6 +77,10 @@ window.onload = function() {
                 localStorage.setItem('migration_completed', 'true');
                 localStorage.removeItem('guestid');
               }
+            } else if (migrateRes.status >= 400 && migrateRes.status < 500) {
+              // 4xx はリトライしても解消しないため再試行させない
+              localStorage.setItem('migration_completed', 'true');
+              console.log('Migration skipped (non-retryable): ' + migrateRes.status);
             } else {
               console.log('Migration API error: ' + migrateRes.status);
             }

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -67,6 +67,7 @@ window.onload = function() {
         sessionStorage.setItem('auth_done', 'true');
 
         // 未移行の guestId があれば Firestore へ移行する
+        let shouldReload = true;
         const existingGuestId = localStorage.getItem('guestid');
         if (existingGuestId && /^[0-9a-fA-F]{32}$/.test(existingGuestId)
             && localStorage.getItem('migration_completed') !== 'true') {
@@ -87,16 +88,23 @@ window.onload = function() {
             } else if (migrateRes.status >= 400 && migrateRes.status < 500) {
               // 4xx はリトライしても解消しないため再試行させない
               localStorage.setItem('migration_completed', 'true');
+              localStorage.removeItem('guestid');
               console.log('Migration skipped (non-retryable): ' + migrateRes.status);
             } else {
+              // 5xx は次回ロード時に再試行させるためリロードしない（ループ防止）
+              shouldReload = false;
               console.log('Migration API error: ' + migrateRes.status);
             }
           } catch (e) {
+            // ネットワークエラー時も同様にリロードしない
+            shouldReload = false;
             console.log('Migration error: ' + e.message);
           }
         }
 
-        location.replace(location.pathname + location.search + location.hash);
+        if (shouldReload) {
+          location.replace(location.pathname + location.search + location.hash);
+        }
       } catch (e) {
         console.log('Firebase auth error (inner): ' + e.message);
       }

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -58,6 +58,33 @@ window.onload = function() {
           return;
         }
         sessionStorage.setItem('auth_done', 'true');
+
+        // 未移行の guestId があれば Firestore へ移行する
+        const existingGuestId = localStorage.getItem('guestid');
+        if (existingGuestId && existingGuestId.length === 32
+            && localStorage.getItem('migration_completed') !== 'true') {
+          try {
+            const migrateRes = await fetch('/api/migrate', {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ idToken: idToken, guestId: existingGuestId })
+            });
+            if (migrateRes.ok) {
+              const result = await migrateRes.json();
+              console.log('Migration: ' + result.message);
+              if (result.success) {
+                localStorage.setItem('migration_completed', 'true');
+                localStorage.removeItem('guestid');
+              }
+            } else {
+              console.log('Migration API error: ' + migrateRes.status);
+            }
+          } catch (e) {
+            console.log('Migration error: ' + e.message);
+          }
+        }
+
         location.replace(location.pathname + location.search + location.hash);
       } catch (e) {
         console.log('Firebase auth error (inner): ' + e.message);

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -23,11 +23,18 @@ window.onload = function() {
 (async function initFirebaseAuth() {
   try {
     // 同一タブ内で認証済みかつサーバーセッションが有効な場合はスキップ（リダイレクトループ防止）
+    // ただし移行未完了の guestId が残っている場合はスキップしない（5xx失敗後の再試行のため）
     if (sessionStorage.getItem('auth_done') === 'true') {
-      const check = await fetch('/api/session', { credentials: 'same-origin' });
-      if (check.ok) return;
-      // サーバーセッションが失効していた場合は再認証する
-      sessionStorage.removeItem('auth_done');
+      const existingGuestId = localStorage.getItem('guestid');
+      const hasPendingMigration = existingGuestId
+        && /^[0-9a-fA-F]{32}$/.test(existingGuestId)
+        && localStorage.getItem('migration_completed') !== 'true';
+      if (!hasPendingMigration) {
+        const check = await fetch('/api/session', { credentials: 'same-origin' });
+        if (check.ok) return;
+        // サーバーセッションが失効していた場合は再認証する
+        sessionStorage.removeItem('auth_done');
+      }
     }
 
     const res = await fetch('/api/firebase/config');

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -68,6 +68,8 @@ window.onload = function() {
         sessionStorage.setItem('auth_done', 'true');
 
         // 未移行の guestId があれば Firestore へ移行する
+        // guestid は Firebase 導入前の旧コードで localStorage に保存されたもの。
+        // 新規ユーザーには存在せず、既存ユーザーの一回限りのデータ移行にのみ使用する。
         // 初回認証後は常にリロード（サーバーセッション確立後の表示反映）
         // 同一タブ内での再試行時は 5xx/エラーでリロードしない（ループ防止）
         const isFirstAuthInTab = !sessionStorage.getItem('session_established');

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -34,6 +34,7 @@ window.onload = function() {
         if (check.ok) return;
         // サーバーセッションが失効していた場合は再認証する
         sessionStorage.removeItem('auth_done');
+        sessionStorage.removeItem('session_established');
       }
     }
 
@@ -67,7 +68,12 @@ window.onload = function() {
         sessionStorage.setItem('auth_done', 'true');
 
         // 未移行の guestId があれば Firestore へ移行する
-        let shouldReload = true;
+        // 初回認証後は常にリロード（サーバーセッション確立後の表示反映）
+        // 同一タブ内での再試行時は 5xx/エラーでリロードしない（ループ防止）
+        const isFirstAuthInTab = !sessionStorage.getItem('session_established');
+        sessionStorage.setItem('session_established', 'true');
+        let shouldReload = isFirstAuthInTab;
+
         const existingGuestId = localStorage.getItem('guestid');
         if (existingGuestId && /^[0-9a-fA-F]{32}$/.test(existingGuestId)
             && localStorage.getItem('migration_completed') !== 'true') {
@@ -84,6 +90,7 @@ window.onload = function() {
               if (result.success) {
                 localStorage.setItem('migration_completed', 'true');
                 localStorage.removeItem('guestid');
+                shouldReload = true; // 移行成功時は常にリロード（移行後データ表示のため）
               }
             } else if (migrateRes.status >= 400 && migrateRes.status < 500) {
               // 4xx はリトライしても解消しないため再試行させない
@@ -91,13 +98,11 @@ window.onload = function() {
               localStorage.removeItem('guestid');
               console.log('Migration skipped (non-retryable): ' + migrateRes.status);
             } else {
-              // 5xx は次回ロード時に再試行させるためリロードしない（ループ防止）
-              shouldReload = false;
+              // 5xx: 初回認証後はリロード（認証済みビュー表示のため）
+              // 同一タブ内の再試行では isFirstAuthInTab=false のためリロードせずループを防止
               console.log('Migration API error: ' + migrateRes.status);
             }
           } catch (e) {
-            // ネットワークエラー時も同様にリロードしない
-            shouldReload = false;
             console.log('Migration error: ' + e.message);
           }
         }

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import jp.developer.bbee.pcassem.DeviceInfoDao.SaveItem;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -141,6 +142,57 @@ class HomeControllerTest {
 
         verify(dao).save(anyString(), eq(FIREBASE_UID), anyList());
         verify(firestoreService).saveSaves(eq(FIREBASE_UID), isNull(), anyList(), anyMap());
+    }
+
+    // ── /rec/{saveId} テスト ──────────────────────────────────────────
+
+    private static final String SAVE_ID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4";
+
+    @Test
+    void restoreConstruction_firestoreHit_returnsRestoredList() throws Exception {
+        SaveItem saveItem = new SaveItem(SAVE_ID, "device-001", 50000,
+                LocalDateTime.now(), LocalDateTime.now());
+        DeviceInfo di = new DeviceInfo("device-001", "cpu", "http://example.com", "Intel Core i9",
+                "http://img.example.com/cpu.jpg", "detail", 55000, 1, 0, 0,
+                "2024-01-01", 0, LocalDateTime.now(), LocalDateTime.now());
+
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(List.of(saveItem));
+        when(dao.findRecordByIds(List.of("device-001"))).thenReturn(List.of(di));
+
+        mockMvc.perform(get("/rec/" + SAVE_ID))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attributeExists("restoredList"));
+
+        verify(firestoreService).getSaveItems(SAVE_ID);
+        verify(dao, never()).restore(anyString());
+    }
+
+    @Test
+    void restoreConstruction_firestoreMiss_h2Hit_returnsRestoredList() throws Exception {
+        HomeController.RestoreDevice rd = new HomeController.RestoreDevice(
+                SAVE_ID, "device-001", "cpu", "http://example.com", "Intel Core i9",
+                "http://img.example.com/cpu.jpg", "detail", 50000, 55000);
+
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(null);
+        when(dao.restore(SAVE_ID)).thenReturn(List.of(rd));
+
+        mockMvc.perform(get("/rec/" + SAVE_ID))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attributeExists("restoredList"));
+
+        verify(firestoreService).getSaveItems(SAVE_ID);
+        verify(dao).restore(SAVE_ID);
+    }
+
+    @Test
+    void restoreConstruction_neitherFound_returns404() throws Exception {
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(null);
+        when(dao.restore(SAVE_ID)).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/rec/" + SAVE_ID))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -199,10 +199,11 @@ class HomeControllerTest {
     @Test
     void restoreConstruction_firestoreError_returns503() throws Exception {
         when(firestoreService.getSaveItems(SAVE_ID)).thenThrow(new RuntimeException("Firestore unavailable"));
-        when(dao.restore(SAVE_ID)).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/rec/" + SAVE_ID))
                 .andExpect(status().isServiceUnavailable());
+
+        verify(dao, never()).restore(anyString());
     }
 
     @Test

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -197,6 +197,15 @@ class HomeControllerTest {
     }
 
     @Test
+    void restoreConstruction_firestoreError_returns503() throws Exception {
+        when(firestoreService.getSaveItems(SAVE_ID)).thenThrow(new RuntimeException("Firestore unavailable"));
+        when(dao.restore(SAVE_ID)).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/rec/" + SAVE_ID))
+                .andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
     void saveConstruction_firestoreException_stillRedirectsToRec() throws Exception {
         doThrow(new RuntimeException("Firestore error"))
                 .when(firestoreService).saveSaves(anyString(), any(), anyList(), anyMap());

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -19,6 +19,7 @@ import jp.developer.bbee.pcassem.DeviceInfoDao.SaveItem;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -156,7 +157,7 @@ class HomeControllerTest {
                 "http://img.example.com/cpu.jpg", "detail", 55000, 1, 0, 0,
                 "2024-01-01", 0, LocalDateTime.now(), LocalDateTime.now());
 
-        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(List.of(saveItem));
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(Optional.of(List.of(saveItem)));
         when(dao.findRecordByIds(List.of("device-001"))).thenReturn(List.of(di));
 
         mockMvc.perform(get("/rec/" + SAVE_ID))
@@ -174,7 +175,7 @@ class HomeControllerTest {
                 SAVE_ID, "device-001", "cpu", "http://example.com", "Intel Core i9",
                 "http://img.example.com/cpu.jpg", "detail", 50000, 55000);
 
-        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(null);
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(Optional.empty());
         when(dao.restore(SAVE_ID)).thenReturn(List.of(rd));
 
         mockMvc.perform(get("/rec/" + SAVE_ID))
@@ -188,7 +189,7 @@ class HomeControllerTest {
 
     @Test
     void restoreConstruction_neitherFound_returns404() throws Exception {
-        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(null);
+        when(firestoreService.getSaveItems(SAVE_ID)).thenReturn(Optional.empty());
         when(dao.restore(SAVE_ID)).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/rec/" + SAVE_ID))

--- a/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
@@ -51,10 +51,25 @@ class MigrationControllerTest {
     }
 
     @Test
-    void migrate_invalidGuestId_returnsBadRequest() throws Exception {
+    void migrate_tooShortGuestId_returnsBadRequest() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
         req.guestId = "tooshort";
+
+        mockMvc.perform(post("/api/migrate")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(migrationService);
+    }
+
+    @Test
+    void migrate_nonHexGuestId_returnsBadRequest() throws Exception {
+        MigrationRequest req = new MigrationRequest();
+        req.idToken = "valid-token";
+        req.guestId = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"; // 32 chars, non-hex
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")

--- a/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -37,9 +36,10 @@ class MigrationControllerTest {
     }
 
     @Test
-    void migrate_noSession_returnsBadRequest() throws Exception {
+    void migrate_missingGuestId_returnsBadRequest() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
+        // guestId なし
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
@@ -51,17 +51,14 @@ class MigrationControllerTest {
     }
 
     @Test
-    void migrate_invalidGuestIdInSession_returnsBadRequest() throws Exception {
+    void migrate_invalidGuestId_returnsBadRequest() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
-
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("guestId", "tooshort");
+        req.guestId = "tooshort";
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(req))
-                        .session(session))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false));
 
@@ -71,14 +68,12 @@ class MigrationControllerTest {
     @Test
     void migrate_missingIdToken_returnsBadRequest() throws Exception {
         MigrationRequest req = new MigrationRequest();
-
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("guestId", VALID_GUEST_ID);
+        req.guestId = VALID_GUEST_ID;
+        // idToken なし
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(req))
-                        .session(session))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false));
 
@@ -89,16 +84,13 @@ class MigrationControllerTest {
     void migrate_validRequest_returnsSuccess() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
-
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("guestId", VALID_GUEST_ID);
+        req.guestId = VALID_GUEST_ID;
 
         when(migrationService.migrate("valid-token", VALID_GUEST_ID)).thenReturn(true);
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(req))
-                        .session(session))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("Migration successful"));
@@ -108,16 +100,13 @@ class MigrationControllerTest {
     void migrate_alreadyMigrated_returnsAlreadyMigrated() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
-
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("guestId", VALID_GUEST_ID);
+        req.guestId = VALID_GUEST_ID;
 
         when(migrationService.migrate("valid-token", VALID_GUEST_ID)).thenReturn(false);
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(req))
-                        .session(session))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.message").value("Already migrated"));
@@ -127,16 +116,13 @@ class MigrationControllerTest {
     void migrate_serviceThrowsException_returnsInternalServerError() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";
-
-        MockHttpSession session = new MockHttpSession();
-        session.setAttribute("guestId", VALID_GUEST_ID);
+        req.guestId = VALID_GUEST_ID;
 
         when(migrationService.migrate(any(), any())).thenThrow(new RuntimeException("DB error"));
 
         mockMvc.perform(post("/api/migrate")
                         .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(req))
-                        .session(session))
+                        .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.success").value(false));
     }

--- a/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/MigrationControllerTest.java
@@ -36,6 +36,17 @@ class MigrationControllerTest {
     }
 
     @Test
+    void migrate_invalidBody_returnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/migrate")
+                        .contentType("application/json")
+                        .content("not-valid-json"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+
+        verifyNoInteractions(migrationService);
+    }
+
+    @Test
     void migrate_missingGuestId_returnsBadRequest() throws Exception {
         MigrationRequest req = new MigrationRequest();
         req.idToken = "valid-token";


### PR DESCRIPTION
This pull request introduces several improvements and refactorings related to device restoration and guest-to-user migration. The main changes are grouped into two themes: device restoration logic and migration flow refactoring.

**Device Restoration Logic:**

* The `/rec/{saveId}` endpoint in `HomeController` now attempts to restore device data from Firestore first, falling back to the H2 database only if not found in Firestore. If the data is not found in either, a 404 Not Found is returned. A helper method was added to map Firestore data to the domain model.
* The `FirestoreService` interface and its implementation now provide a `getSaveItems` method to retrieve device save items from Firestore, returning `Optional.empty()` if the document doesn't exist and `Optional.of(items)` if it does.

**Migration Flow Refactoring:**

* The migration API (`/api/migrate`) no longer relies on the session for `guestId`. Instead, the client must provide `guestId` in the request body. The controller, request class, and all related tests have been updated accordingly.
* The frontend (`main.js`) now checks for an unmigrated `guestId` in `localStorage` after authentication and triggers the migration API, passing both `idToken` and `guestId`. On success, it marks migration as complete and removes the `guestId` from storage. On 5xx / network error, it reloads once on the first authentication in the tab (so the user sees the authenticated view) but skips the reload on subsequent retries in the same tab to prevent a tight reload loop.

These changes improve reliability and maintainability by making device restoration more robust and migration logic more explicit and testable.