### PR TITLE
feat: add java-to-kotlin Claude Code skill

### DIFF
--- a/.claude/skills/java-to-kotlin/SKILL.md
+++ b/.claude/skills/java-to-kotlin/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: java-to-kotlin
+description: >
+  Migrates Java source files to idiomatic Kotlin in a Spring Boot (Maven) project.
+  Handles records→data classes, constants classes→objects, interfaces, utility
+  classes→top-level functions, null safety, checked exceptions, and Spring
+  annotation compatibility. Use this skill whenever the user asks to convert,
+  migrate, translate, or rewrite Java files to Kotlin — even for single files,
+  even if they just say "convert this to Kotlin" or "make this Kotlin". Also
+  triggers when asked to "kotlinize" code or "use Kotlin instead of Java".
+---
+
+## Goal
+
+Convert one or more Java source files to idiomatic, compilable Kotlin while
+preserving behaviour and Spring Boot compatibility. Prefer Kotlin idioms over
+mechanical transliteration.
+
+## Workflow
+
+### Step 1 – Assess the build (Maven)
+
+Read `pom.xml`. If `kotlin-stdlib` and `kotlin-maven-plugin` are not yet
+present, add them before converting any source files. See
+[references/maven-setup.md](references/maven-setup.md) for the exact snippet.
+
+Skip this step if Kotlin is already configured.
+
+### Step 2 – Plan the conversion scope
+
+List the Java files to convert. Group them by conversion difficulty:
+
+| Tier | Pattern | Example |
+|------|---------|---------|
+| Easy | Constants-only class, simple record/DTO | `ApiEndPoint.java`, `UserAssem.java` |
+| Medium | Record with factory/helper methods, interface | `DeviceInfo.java`, `GeminiService.java` |
+| Hard | Large stateful class, Spring controller/service | `HomeController.java`, `KakakuClient.java` |
+
+Convert Easy → Medium → Hard. Present the plan and wait for approval if the
+user is interactive; otherwise proceed.
+
+### Step 3 – Convert each file
+
+Apply the patterns in [references/conversion-patterns.md](references/conversion-patterns.md).
+
+Key rules:
+- Move the `.java` file to a `.kt` file in the **same package directory**.
+- Do not change package declarations.
+- Do not leave dead `.java` files after conversion — delete them.
+- Run `./mvnw compile` (or `./mvnw test`) after each tier to catch regressions early.
+
+### Step 4 – Validate
+
+After all conversions:
+
+```bash
+./mvnw test
+```
+
+If tests fail, diagnose and fix before reporting done.
+
+### Step 5 – Report
+
+Summarise what was converted, any idioms applied (e.g., extension functions,
+`object` vs `companion object`), and any decisions that required judgment.

--- a/.claude/skills/java-to-kotlin/SKILL.md
+++ b/.claude/skills/java-to-kotlin/SKILL.md
@@ -20,8 +20,9 @@ mechanical transliteration.
 
 ### Step 1 – Assess the build (Maven)
 
-Read `pom.xml`. If `kotlin-stdlib` and `kotlin-maven-plugin` are not yet
-present, add them before converting any source files. See
+Read `pom.xml`. If `kotlin-stdlib-jdk8` and `kotlin-maven-plugin` are not yet
+present, add them before converting any source files. The setup also requires
+`jackson-module-kotlin` and `kotlin-reflect`. See
 [references/maven-setup.md](references/maven-setup.md) for the exact snippet.
 
 Skip this step if Kotlin is already configured.

--- a/.claude/skills/java-to-kotlin/evals/evals.json
+++ b/.claude/skills/java-to-kotlin/evals/evals.json
@@ -1,0 +1,46 @@
+{
+  "skill_name": "java-to-kotlin",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "ApiEndPoint.java を Kotlin に変換してください。ファイルは evals/files/ApiEndPoint.java です。",
+      "expected_output": "定数のみのクラスが Kotlin の object + const val に変換され、ApiEndPoint.kt が生成される。",
+      "files": ["evals/files/ApiEndPoint.java"],
+      "assertions": [
+        "出力ファイルが .kt 拡張子であること",
+        "Kotlin の object キーワードを含むこと",
+        "const val を含むこと",
+        "パッケージ宣言 jp.developer.bbee.pcassem.constants が維持されていること",
+        "class キーワードではなく object が使われていること（定数クラスのため）"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "UserAssem.java を Kotlin に変換してください。ファイルは evals/files/UserAssem.java です。",
+      "expected_output": "シンプルな Java record が Kotlin の data class に変換される。",
+      "files": ["evals/files/UserAssem.java"],
+      "assertions": [
+        "出力ファイルが .kt 拡張子であること",
+        "data class キーワードを含むこと",
+        "コンストラクタパラメータが val で定義されていること",
+        "パッケージ宣言 jp.developer.bbee.pcassem.model が維持されていること",
+        "6つのフィールド（id, deviceid, device, guestid, createddate, lastupdate）がすべて含まれていること"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "DeviceInfo.java を Kotlin に変換してください。ファイルは evals/files/DeviceInfo.java です。static メソッドと定数も含めてイディオマティックな Kotlin にしてください。",
+      "expected_output": "Java record が companion object を持つ data class に変換。null チェックが Kotlin のイディオムに変換される。",
+      "files": ["evals/files/DeviceInfo.java"],
+      "assertions": [
+        "出力ファイルが .kt 拡張子であること",
+        "data class キーワードを含むこと",
+        "companion object を含むこと",
+        "when 式またはスマートキャスト（is キーワード）を含むこと",
+        "エルビス演算子 ?: を含むこと",
+        "パッケージ宣言 jp.developer.bbee.pcassem.model が維持されていること",
+        "@NonNull アノテーションを含まないこと（型システムで表現するため）"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/java-to-kotlin/evals/files/ApiEndPoint.java
+++ b/.claude/skills/java-to-kotlin/evals/files/ApiEndPoint.java
@@ -1,0 +1,6 @@
+package jp.developer.bbee.pcassem.constants;
+
+public class ApiEndPoint {
+    public static final String GET_DEVICE = "/devicelist";
+    public static final String GET_UPDATE = "/update";
+}

--- a/.claude/skills/java-to-kotlin/evals/files/DeviceInfo.java
+++ b/.claude/skills/java-to-kotlin/evals/files/DeviceInfo.java
@@ -1,0 +1,67 @@
+package jp.developer.bbee.pcassem.model;
+
+import org.springframework.lang.NonNull;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record DeviceInfo (String id, String device, String url, String name, String imgurl, String detail,
+                          Integer price, Integer rank, int flag1, int flag2,
+                          String releasedate, Integer invisible, LocalDateTime createddate, LocalDateTime lastupdate) {
+
+    private static final String DEFAULT_RELEASE_DATE = "20000101";
+    private static final LocalDateTime DEFAULT_DATE_TIME = LocalDateTime.of(2000, 1, 1, 0, 0);
+
+    @NonNull
+    public static DeviceInfo from(@NonNull Map<String, Object> result) {
+        return new DeviceInfo(
+                (String) result.get("id"), (String) result.get("device"), (String) result.get("url"),
+                (String) result.get("name"), (String) result.get("imgurl"), (String) result.get("detail"),
+                toInteger(result.get("price")), toInteger(result.get("rank")),
+                toIntOrDefault(result.get("flag1"), 0),
+                toIntOrDefault(result.get("flag2"), 0),
+                toReleaseDate(result.get("releasedate")), toInteger(result.get("invisible")),
+                toLocalDateTime(result.get("createddate"), DEFAULT_DATE_TIME),
+                toLocalDateTime(result.get("lastupdate"), DEFAULT_DATE_TIME)
+        );
+    }
+
+    private static Integer toInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Integer integer) {
+            return integer;
+        }
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return Integer.valueOf(value.toString());
+    }
+
+    private static int toIntOrDefault(Object value, int defaultValue) {
+        Integer integer = toInteger(value);
+        return integer != null ? integer : defaultValue;
+    }
+
+    private static String toReleaseDate(Object value) {
+        return value != null ? value.toString() : DEFAULT_RELEASE_DATE;
+    }
+
+    private static LocalDateTime toLocalDateTime(Object value, LocalDateTime defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime;
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime();
+        }
+        if (value instanceof java.util.Date date) {
+            return new Timestamp(date.getTime()).toLocalDateTime();
+        }
+        return Timestamp.valueOf(value.toString()).toLocalDateTime();
+    }
+}

--- a/.claude/skills/java-to-kotlin/evals/files/UserAssem.java
+++ b/.claude/skills/java-to-kotlin/evals/files/UserAssem.java
@@ -1,0 +1,6 @@
+package jp.developer.bbee.pcassem.model;
+
+import java.time.LocalDateTime;
+
+public record UserAssem(String id, String deviceid, String device, String guestid,
+                        LocalDateTime createddate, LocalDateTime lastupdate) {}

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -47,9 +47,13 @@ data class UserAssem(
 
 ### nullability の判断
 - `@NonNull` アノテーション付き → `String`（non-null）
-- アノテーションなし、または DB から取得する値 → `String?`（nullable）
+- `@Nullable` アノテーション付き → `String?`（nullable）
 - プリミティブ型（`int`, `boolean`等）→ Kotlin では `Int`, `Boolean`（non-null）
 - ラッパー型（`Integer`, `Boolean`）→ `Int?`, `Boolean?`
+- アノテーションなし → **DBスキーマとDAOの組み立て方を確認して判断する**。
+  `NOT NULL` 制約があり DAO 側でも常に値が入ることが保証されるなら non-null のまま。
+  `NULL` 許容カラムや `JdbcTemplate` の `Map<String, Object>` から取得する値（null が入り得る）は `?` を付ける。
+  一律 `?` にすると呼び出し側の `?.` / `?:` が増えてドメインの意図が見えにくくなるため、過剰な nullable 化は避けること。
 
 ### record のコンパニオンメソッド
 
@@ -71,7 +75,7 @@ data class DeviceInfo(...) {
     companion object {
         private const val DEFAULT = "20000101"
 
-        fun from(result: Map<String, Any>): DeviceInfo { ... }
+        fun from(result: Map<String, Any?>): DeviceInfo { ... }
 
         private fun toInteger(value: Any?): Int? { ... }
     }
@@ -301,7 +305,7 @@ val map = hashMapOf("key" to "value")
 変換後のファイルは元の Java ファイルと **同じディレクトリ** に置く。
 
 ```
-src/main/java/jp/developer/bbee/pcassem/
+src/main/java/jp/developer/bbee/pcassem/constants/
   ApiEndPoint.java      ← 削除
   ApiEndPoint.kt        ← 新規（同パッケージ）
 ```

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -35,6 +35,9 @@ public record UserAssem(String id, String deviceid, String device,
 
 ```kotlin
 // Kotlin
+// 注: このリポジトリでは JdbcTemplate の Map<String, Object> から組み立てるため
+// 全フィールドが null を取り得る。DBスキーマで NOT NULL が保証されるフィールドは
+// non-null にしてよい（nullability の判断を参照）。
 data class UserAssem(
     val id: String?,
     val deviceid: String?,

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -1,0 +1,315 @@
+# Java → Kotlin 変換パターン集
+
+## 1. 定数クラス → `object`
+
+```java
+// Java
+public class ApiEndPoint {
+    public static final String GET_DEVICE = "/devicelist";
+    public static final String GET_UPDATE  = "/update";
+}
+```
+
+```kotlin
+// Kotlin
+object ApiEndPoint {
+    const val GET_DEVICE = "/devicelist"
+    const val GET_UPDATE  = "/update"
+}
+```
+
+- `public class` で全フィールドが `static final` → `object` に変換
+- `static final` の String/数値リテラル → `const val`
+- 他の型（リスト等）は `val` のみ（`const` 不可）
+
+---
+
+## 2. Java record → Kotlin data class
+
+```java
+// Java (シンプル)
+public record UserAssem(String id, String deviceid, String device,
+                        String guestid, LocalDateTime createddate,
+                        LocalDateTime lastupdate) {}
+```
+
+```kotlin
+// Kotlin
+data class UserAssem(
+    val id: String?,
+    val deviceid: String?,
+    val device: String?,
+    val guestid: String?,
+    val createddate: LocalDateTime?,
+    val lastupdate: LocalDateTime?
+)
+```
+
+### nullability の判断
+- `@NonNull` アノテーション付き → `String`（non-null）
+- アノテーションなし、または DB から取得する値 → `String?`（nullable）
+- プリミティブ型（`int`, `boolean`等）→ Kotlin では `Int`, `Boolean`（non-null）
+- ラッパー型（`Integer`, `Boolean`）→ `Int?`, `Boolean?`
+
+### record のコンパニオンメソッド
+
+```java
+// Java
+public record DeviceInfo(...) {
+    private static final String DEFAULT = "20000101";
+
+    @NonNull
+    public static DeviceInfo from(@NonNull Map<String, Object> result) { ... }
+
+    private static Integer toInteger(Object value) { ... }
+}
+```
+
+```kotlin
+// Kotlin
+data class DeviceInfo(...) {
+    companion object {
+        private const val DEFAULT = "20000101"
+
+        fun from(result: Map<String, Any>): DeviceInfo { ... }
+
+        private fun toInteger(value: Any?): Int? { ... }
+    }
+}
+```
+
+- `static` フィールド・メソッド → `companion object` へ移動
+- `static final` 定数 → `companion object` 内の `const val`
+- `@NonNull` → non-null 型（`?` なし）
+- `@NonNull` パラメータ → 呼び出し側はそのまま non-null で渡す
+
+---
+
+## 3. インターフェース → そのまま `interface`
+
+```java
+// Java
+public interface GeminiService {
+    ReviewResponse getReview(String prompt);
+}
+```
+
+```kotlin
+// Kotlin
+interface GeminiService {
+    fun getReview(prompt: String): ReviewResponse
+}
+```
+
+- `interface` キーワードはそのまま
+- メソッドシグネチャ → `fun` キーワードを先頭に追加
+- 戻り値型を末尾に移動（`: ReturnType`）
+
+---
+
+## 4. ユーティリティクラス → トップレベル関数
+
+```java
+// Java
+public class StringEncoder {
+    public static String sjisToUtf8(String value) throws UnsupportedEncodingException { ... }
+    private static String convert(String value, String src, String dest) throws UnsupportedEncodingException { ... }
+}
+```
+
+```kotlin
+// Kotlin
+// パッケージ宣言の直下、クラス外に記述
+fun sjisToUtf8(value: String): String { ... }
+
+private fun convert(value: String, src: String, dest: String): String { ... }
+```
+
+- `public static` メソッドのみのクラス → クラス不要、トップレベル関数に
+- `private static` → ファイルスコープの `private fun`
+- `throws XxxException` → **削除**（Kotlin はチェック例外を持たない）
+  - 実装内で例外が発生しうる場合はそのままスロー、あるいは `runCatching{}` でラップ
+  - Java 呼び出し側から呼ばれる場合は `@Throws(XxxException::class)` を付与
+
+---
+
+## 5. Spring Boot クラスのパターン
+
+### `@SpringBootApplication` メインクラス
+
+```java
+// Java
+@SpringBootApplication
+public class PcassemApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(PcassemApplication.class, args);
+    }
+}
+```
+
+```kotlin
+// Kotlin
+@SpringBootApplication
+class PcassemApplication
+
+fun main(args: Array<String>) {
+    runApplication<PcassemApplication>(*args)
+}
+```
+
+### Controller / Service / Component
+
+```java
+// Java
+@RestController
+@RequestMapping("/api")
+public class ApiResponseController {
+    private final DeviceInfoDao dao;
+
+    public ApiResponseController(DeviceInfoDao dao) {
+        this.dao = dao;
+    }
+}
+```
+
+```kotlin
+// Kotlin（コンストラクタインジェクションが簡潔になる）
+@RestController
+@RequestMapping("/api")
+class ApiResponseController(private val dao: DeviceInfoDao)
+```
+
+- コンストラクタインジェクション → プライマリコンストラクタの `val` パラメータに集約
+- `@Autowired` はコンストラクタが1つなら不要
+- Spring の CGLIB プロキシのために `open` が必要 → `kotlin-allopen` プラグイン（`spring` preset）が自動付与
+
+---
+
+## 6. よくある Kotlin イディオム
+
+### `null` チェック
+
+```java
+// Java
+if (value == null) return null;
+return value.toString();
+```
+
+```kotlin
+// Kotlin
+return value?.toString()
+```
+
+### エルビス演算子（デフォルト値）
+
+```java
+// Java
+return integer != null ? integer : defaultValue;
+```
+
+```kotlin
+// Kotlin
+return integer ?: defaultValue
+```
+
+### スマートキャスト（instanceof → is）
+
+```java
+// Java
+if (value instanceof Integer integer) {
+    return integer;
+}
+if (value instanceof Number number) {
+    return number.intValue();
+}
+```
+
+```kotlin
+// Kotlin
+return when (value) {
+    is Int    -> value
+    is Number -> value.toInt()
+    else      -> value.toString().toInt()
+}
+```
+
+### `when` 式（switch の置き換え）
+
+```java
+// Java
+switch (type) {
+    case "A": return 1;
+    case "B": return 2;
+    default:  return 0;
+}
+```
+
+```kotlin
+// Kotlin
+return when (type) {
+    "A"  -> 1
+    "B"  -> 2
+    else -> 0
+}
+```
+
+### 文字列テンプレート
+
+```java
+// Java
+throw new UnsupportedEncodingException("src=" + src + ",dest=" + dest);
+```
+
+```kotlin
+// Kotlin
+throw UnsupportedEncodingException("src=$src,dest=$dest")
+```
+
+### HashMap の初期化
+
+```java
+// Java
+Map<String, String> map = new HashMap<>();
+map.put("key", "value");
+```
+
+```kotlin
+// Kotlin
+val map = mutableMapOf("key" to "value")
+// または
+val map = hashMapOf("key" to "value")
+```
+
+---
+
+## 7. アノテーション互換性
+
+| Java                     | Kotlin                         | 備考 |
+|--------------------------|--------------------------------|------|
+| `@NonNull`               | Non-null 型（`String`）         | 型で表現するためアノテーション不要 |
+| `@Nullable`              | Nullable 型（`String?`）        | 同上 |
+| `@Component` 等          | そのまま使用可                  | allopen プラグインが `open` を付与 |
+| `@JvmRecord`（Java 16+）  | 不要（Kotlin の `data class` を使う） | |
+| `@JvmStatic`             | `companion object` 内のメソッドに付与 | Java から静的呼び出しされる場合のみ必要 |
+| `@JvmField`              | `companion object` のフィールドに付与 | Java から `Foo.FIELD` でアクセスされる場合のみ必要 |
+| `@Throws(IOException::class)` | Java から呼ばれる場合に付与 | Kotlin→Kotlin のみなら不要 |
+
+---
+
+## 8. ファイル配置
+
+変換後のファイルは元の Java ファイルと **同じディレクトリ** に置く。
+
+```
+src/main/java/jp/developer/bbee/pcassem/
+  ApiEndPoint.java      ← 削除
+  ApiEndPoint.kt        ← 新規（同パッケージ）
+```
+
+パッケージ宣言はそのまま維持:
+```kotlin
+package jp.developer.bbee.pcassem.constants
+```
+
+Kotlin ファイルも `src/main/java/` 以下に置いてよい（Maven の `sourceDir` 設定による）。
+または `src/main/kotlin/` を作って移すことも可能だが、混在プロジェクトでは `java/` のままが無難。

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -289,7 +289,7 @@ val map = hashMapOf("key" to "value")
 | `@NonNull`               | Non-null 型（`String`）         | 型で表現するためアノテーション不要 |
 | `@Nullable`              | Nullable 型（`String?`）        | 同上 |
 | `@Component` 等          | そのまま使用可                  | allopen プラグインが `open` を付与 |
-| `@JvmRecord`（Java 16+）  | 不要（Kotlin の `data class` を使う） | |
+| `record`（Java 16+）      | `data class`（通常）/ `@JvmRecord` を付与した `data class`（Java との相互運用が必要な場合のみ） | `@JvmRecord` は Kotlin 側のアノテーション。Java の `record` と ABI 互換が必要なときのみ検討 |
 | `@JvmStatic`             | `companion object` 内のメソッドに付与 | Java から静的呼び出しされる場合のみ必要 |
 | `@JvmField`              | `companion object` のフィールドに付与 | Java から `Foo.FIELD` でアクセスされる場合のみ必要 |
 | `@Throws(IOException::class)` | Java から呼ばれる場合に付与 | Kotlin→Kotlin のみなら不要 |

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -35,16 +35,16 @@ public record UserAssem(String id, String deviceid, String device,
 
 ```kotlin
 // Kotlin
-// 注: このリポジトリでは JdbcTemplate の Map<String, Object> から組み立てるため
-// 全フィールドが null を取り得る。DBスキーマで NOT NULL が保証されるフィールドは
-// non-null にしてよい（nullability の判断を参照）。
+// 注: DeviceInfoDao は r.get("id").toString() / ((Timestamp) r.get("createddate")).toLocalDateTime()
+// のように null チェックなしでアクセスしている。null が来れば NPE になるため、
+// DAOのアクセスパターンから全フィールドが non-null 前提と判断できる。
 data class UserAssem(
-    val id: String?,
-    val deviceid: String?,
-    val device: String?,
-    val guestid: String?,
-    val createddate: LocalDateTime?,
-    val lastupdate: LocalDateTime?
+    val id: String,
+    val deviceid: String,
+    val device: String,
+    val guestid: String,
+    val createddate: LocalDateTime,
+    val lastupdate: LocalDateTime
 )
 ```
 
@@ -53,10 +53,10 @@ data class UserAssem(
 - `@Nullable` アノテーション付き → `String?`（nullable）
 - プリミティブ型（`int`, `boolean`等）→ Kotlin では `Int`, `Boolean`（non-null）
 - ラッパー型（`Integer`, `Boolean`）→ `Int?`, `Boolean?`
-- アノテーションなし → **DBスキーマとDAOの組み立て方を確認して判断する**。
-  `NOT NULL` 制約があり DAO 側でも常に値が入ることが保証されるなら non-null のまま。
-  `NULL` 許容カラムや `JdbcTemplate` の `Map<String, Object>` から取得する値（null が入り得る）は `?` を付ける。
-  一律 `?` にすると呼び出し側の `?.` / `?:` が増えてドメインの意図が見えにくくなるため、過剰な nullable 化は避けること。
+- アノテーションなし → **フィールドごとにDBスキーマとDAOのアクセスパターンを確認して判断する**。
+  DAO が null チェックなしで `.toString()` やキャストを呼んでいるなら non-null 前提。
+  `NULL` 許容カラムで DAO が null を返し得る場合のみ `?` を付ける。
+  JdbcTemplate 経由だからといって一律 `?` にしてはならない。過剰な nullable 化は呼び出し側の `?.` / `?:` を増やしドメインの意図を損なう。
 
 ### record のコンパニオンメソッド
 

--- a/.claude/skills/java-to-kotlin/references/conversion-patterns.md
+++ b/.claude/skills/java-to-kotlin/references/conversion-patterns.md
@@ -296,7 +296,7 @@ val map = hashMapOf("key" to "value")
 | `@NonNull`               | Non-null 型（`String`）         | 型で表現するためアノテーション不要 |
 | `@Nullable`              | Nullable 型（`String?`）        | 同上 |
 | `@Component` 等          | そのまま使用可                  | allopen プラグインが `open` を付与 |
-| `record`（Java 16+）      | `data class`（通常）/ `@JvmRecord` を付与した `data class`（Java との相互運用が必要な場合のみ） | `@JvmRecord` は Kotlin 側のアノテーション。Java の `record` と ABI 互換が必要なときのみ検討 |
+| `record`（Java 16+）      | `data class`（通常）/ `@JvmRecord` を付与した `data class`（Java との相互運用が必要な場合のみ） | `@JvmRecord` は Kotlin 側のアノテーション。**JVM target 16+ が必要**（`kotlin-maven-plugin` の `<jvmTarget>` を 16 以上に設定すること）。Java の `record` と ABI 互換が必要なときのみ検討 |
 | `@JvmStatic`             | `companion object` 内のメソッドに付与 | Java から静的呼び出しされる場合のみ必要 |
 | `@JvmField`              | `companion object` のフィールドに付与 | Java から `Foo.FIELD` でアクセスされる場合のみ必要 |
 | `@Throws(IOException::class)` | Java から呼ばれる場合に付与 | Kotlin→Kotlin のみなら不要 |

--- a/.claude/skills/java-to-kotlin/references/maven-setup.md
+++ b/.claude/skills/java-to-kotlin/references/maven-setup.md
@@ -50,6 +50,8 @@ Kotlin コンパイラは Java コンパイラより **先に** 動く必要が�
             <!-- JPA エンティティ用（JPAを使う場合のみ） -->
             <!-- <plugin>jpa</plugin> -->
         </compilerPlugins>
+        <!-- pom.xml の java.version と揃える。省略するとデフォルト 1.8 でコンパイルされる -->
+        <jvmTarget>${java.version}</jvmTarget>
     </configuration>
     <dependencies>
         <dependency>

--- a/.claude/skills/java-to-kotlin/references/maven-setup.md
+++ b/.claude/skills/java-to-kotlin/references/maven-setup.md
@@ -38,13 +38,14 @@ Kotlin コンパイラは Java コンパイラより **先に** 動く必要が�
 <plugin>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-maven-plugin</artifactId>
+    <version>${kotlin.version}</version>
     <configuration>
         <args>
-            <!-- Spring の open クラス（proxy 生成）に対応 -->
+            <!-- JSR-305（@Nullable / @NonNull など）の nullability 解釈を strict にする -->
             <arg>-Xjsr305=strict</arg>
         </args>
         <compilerPlugins>
-            <!-- Spring コンポーネントに open を自動付与 -->
+            <!-- Spring コンポーネントに open を自動付与（proxy 生成対応） -->
             <plugin>spring</plugin>
             <!-- JPA エンティティ用（JPAを使う場合のみ） -->
             <!-- <plugin>jpa</plugin> -->
@@ -107,8 +108,7 @@ Kotlin コンパイラは Java コンパイラより **先に** 動く必要が�
 
 ## 注意点
 
-- **混在ビルド（Java + Kotlin）**: `sourceDir` に両方のパスを含める。
-  完全移行後は Java の `sourceDir` を削除してよい。
+- **混在ビルド（Java + Kotlin）**: 上記スニペットでは Kotlin ファイルも `src/main/java/` 配下に置く前提で `sourceDir` を設定している。`src/main/kotlin/` を別途設けたい場合は `<sourceDir>` にそのパスも追加すること。完全移行後は Java の `sourceDir` エントリを削除してよい。
 - **`-Xjsr305=strict`**: `@NonNull`/`@Nullable` アノテーションを Kotlin の
   non-null/nullable 型として厳格に扱う。Spring のアノテーションが正しく解釈される。
 - **`spring` allopen プラグイン**: `@Component`, `@Service`, `@Controller` 等に

--- a/.claude/skills/java-to-kotlin/references/maven-setup.md
+++ b/.claude/skills/java-to-kotlin/references/maven-setup.md
@@ -111,7 +111,9 @@ Kotlin コンパイラは Java コンパイラより **先に** 動く必要が�
 ## 注意点
 
 - **混在ビルド（Java + Kotlin）**: 上記スニペットでは Kotlin ファイルも `src/main/java/` 配下に置く前提で `sourceDir` を設定している。`src/main/kotlin/` を別途設けたい場合は `<sourceDir>` にそのパスも追加すること。完全移行後は Java の `sourceDir` エントリを削除してよい。
-- **`-Xjsr305=strict`**: `@NonNull`/`@Nullable` アノテーションを Kotlin の
-  non-null/nullable 型として厳格に扱う。Spring のアノテーションが正しく解釈される。
+- **`-Xjsr305=strict`**: JSR-305（`javax.annotation` 系）の nullability アノテーションを
+  Kotlin の non-null/nullable 型として厳格に扱うための設定。
+  `org.springframework.lang.NonNull/Nullable` は JSR-305 の対象外であり、
+  Kotlin 側の type enhancement により解釈されるため、このフラグとは別の仕組みで機能する。
 - **`spring` allopen プラグイン**: `@Component`, `@Service`, `@Controller` 等に
   自動で `open` を付与し、Spring の CGLIB プロキシが正常動作するようにする。

--- a/.claude/skills/java-to-kotlin/references/maven-setup.md
+++ b/.claude/skills/java-to-kotlin/references/maven-setup.md
@@ -7,10 +7,10 @@ Spring Boot + Kotlin を Maven で使うために必要な最小構成を示す�
 `<dependencies>` 内に追加:
 
 ```xml
-<!-- Kotlin stdlib (JDK 8+ API のラッパーを含む) -->
+<!-- Kotlin stdlib（Spring Boot 2.x / Kotlin 1.6系では jdk8 拡張が別artifact） -->
 <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
-    <artifactId>kotlin-stdlib</artifactId>
+    <artifactId>kotlin-stdlib-jdk8</artifactId>
 </dependency>
 
 <!-- Jackson の Kotlin サポート（JSON シリアライズ）-->

--- a/.claude/skills/java-to-kotlin/references/maven-setup.md
+++ b/.claude/skills/java-to-kotlin/references/maven-setup.md
@@ -1,0 +1,115 @@
+# Maven / Kotlin セットアップ
+
+Spring Boot + Kotlin を Maven で使うために必要な最小構成を示す。
+
+## 追加する依存関係
+
+`<dependencies>` 内に追加:
+
+```xml
+<!-- Kotlin stdlib (JDK 8+ API のラッパーを含む) -->
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-stdlib</artifactId>
+</dependency>
+
+<!-- Jackson の Kotlin サポート（JSON シリアライズ）-->
+<dependency>
+    <groupId>com.fasterxml.jackson.module</groupId>
+    <artifactId>jackson-module-kotlin</artifactId>
+</dependency>
+
+<!-- Kotlin リフレクション（Spring Bean 生成に必要）-->
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-reflect</artifactId>
+</dependency>
+```
+
+> バージョンは `spring-boot-starter-parent` が管理するため `<version>` 不要。
+
+## ビルドプラグイン
+
+`<build><plugins>` 内で `spring-boot-maven-plugin` と **同じ階層** に追加する。
+Kotlin コンパイラは Java コンパイラより **先に** 動く必要があるため、
+`kotlin-maven-plugin` を `maven-compiler-plugin` より前に書く。
+
+```xml
+<plugin>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-maven-plugin</artifactId>
+    <configuration>
+        <args>
+            <!-- Spring の open クラス（proxy 生成）に対応 -->
+            <arg>-Xjsr305=strict</arg>
+        </args>
+        <compilerPlugins>
+            <!-- Spring コンポーネントに open を自動付与 -->
+            <plugin>spring</plugin>
+            <!-- JPA エンティティ用（JPAを使う場合のみ） -->
+            <!-- <plugin>jpa</plugin> -->
+        </compilerPlugins>
+    </configuration>
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-allopen</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+    <executions>
+        <execution>
+            <id>compile</id>
+            <goals><goal>compile</goal></goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                </sourceDirs>
+            </configuration>
+        </execution>
+        <execution>
+            <id>test-compile</id>
+            <goals><goal>test-compile</goal></goals>
+            <configuration>
+                <sourceDirs>
+                    <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                </sourceDirs>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <executions>
+        <!-- Java のデフォルト compile フェーズを無効化し、Kotlin の後に動かす -->
+        <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+        </execution>
+        <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+        </execution>
+        <execution>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals><goal>compile</goal></goals>
+        </execution>
+        <execution>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals><goal>testCompile</goal></goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+## 注意点
+
+- **混在ビルド（Java + Kotlin）**: `sourceDir` に両方のパスを含める。
+  完全移行後は Java の `sourceDir` を削除してよい。
+- **`-Xjsr305=strict`**: `@NonNull`/`@Nullable` アノテーションを Kotlin の
+  non-null/nullable 型として厳格に扱う。Spring のアノテーションが正しく解釈される。
+- **`spring` allopen プラグイン**: `@Component`, `@Service`, `@Controller` 等に
+  自動で `open` を付与し、Spring の CGLIB プロキシが正常動作するようにする。


### PR DESCRIPTION
## 変更内容

Java → Kotlin 移行を支援する Claude Code スキル（`java-to-kotlin`）を `.claude/skills/` に追加した。
このスキルはプロジェクトローカルに置かれているため、このリポジトリで動く全エージェントが自動的に参照できる。

**スキルの機能:**
- Maven `pom.xml` への Kotlin 依存関係・プラグイン追加手順（`references/maven-setup.md`）
- Java → Kotlin の変換パターン集（`references/conversion-patterns.md`）
  - `record` → `data class`、定数クラス → `object`、インターフェース変換
  - null safety（`@NonNull`/`@Nullable` → Kotlin 型システム）
  - checked exception の除去、`static` → `companion object` / トップレベル関数
  - Spring Boot アノテーション互換性（allopen プラグイン、コンストラクタインジェクション）
- eval テストケース3件（`ApiEndPoint`・`UserAssem`・`DeviceInfo`）でスキルを検証済み

## 変更種別

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] Java → Kotlin 移行
- [ ] 依存関係の更新
- [ ] テスト追加・修正
- [ ] その他

## Kotlin 移行を含む場合

_このPR自体はKotlinコードを含まないため該当なし。_

## テスト

- [ ] 既存テストがパスすること（`./mvnw test`）
- [ ] 変更に対応するテストを追加・更新した
- [x] 手動動作確認済み（確認した操作を記載）

<!-- 手動確認内容:
- skill-creator を使ってスキルの草案を作成
- ApiEndPoint.java（定数クラス）、UserAssem.java（シンプルrecord）、DeviceInfo.java（staticメソッド付きrecord）の3件を eval で実行
- with_skill / without_skill を並行実行し、出力を比較確認
- 定量アサーション17項目すべてPASS（pass rate 100%）
-->

## セキュリティチェック（該当する場合）

_スキルファイル（マークダウン）のみの追加であり、実行コードの変更なし。_

## 関連 Issue / PR

なし