### PR TITLE
feat: add Kotlin support and migrate easy-tier classes to Kotlin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
 						<configuration>
 							<sourceDirs>
 								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+								<sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
 							</sourceDirs>
 						</configuration>
 					</execution>
@@ -123,6 +124,7 @@
 						<configuration>
 							<sourceDirs>
 								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+								<sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
 							</sourceDirs>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>Assembly builder for PC</description>
 	<properties>
 		<java.version>17</java.version>
+		<kotlin.version>1.9.25</kotlin.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -26,6 +27,21 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
 		</dependency>
 
 
@@ -71,6 +87,71 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<configuration>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+					<jvmTarget>${java.version}</jvmTarget>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals><goal>compile</goal></goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/main/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<goals><goal>test-compile</goal></goals>
+						<configuration>
+							<sourceDirs>
+								<sourceDir>${project.basedir}/src/test/java</sourceDir>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals><goal>compile</goal></goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals><goal>testCompile</goal></goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/jp/developer/bbee/pcassem/constants/ApiEndPoint.java
+++ b/src/main/java/jp/developer/bbee/pcassem/constants/ApiEndPoint.java
@@ -1,6 +1,0 @@
-package jp.developer.bbee.pcassem.constants;
-
-public class ApiEndPoint {
-    public static final String GET_DEVICE = "/devicelist";
-    public static final String GET_UPDATE = "/update";
-}

--- a/src/main/java/jp/developer/bbee/pcassem/constants/ApiEndPoint.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/constants/ApiEndPoint.kt
@@ -1,0 +1,6 @@
+package jp.developer.bbee.pcassem.constants
+
+object ApiEndPoint {
+    const val GET_DEVICE = "/devicelist"
+    const val GET_UPDATE = "/update"
+}

--- a/src/main/java/jp/developer/bbee/pcassem/constants/DateTimeConst.java
+++ b/src/main/java/jp/developer/bbee/pcassem/constants/DateTimeConst.java
@@ -1,7 +1,0 @@
-package jp.developer.bbee.pcassem.constants;
-
-import java.time.LocalDateTime;
-
-public class DateTimeConst {
-    public static final LocalDateTime FALLBACK = LocalDateTime.of(2000, 1, 1, 0, 0);
-}

--- a/src/main/java/jp/developer/bbee/pcassem/constants/DateTimeConst.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/constants/DateTimeConst.kt
@@ -1,0 +1,8 @@
+package jp.developer.bbee.pcassem.constants
+
+import java.time.LocalDateTime
+
+object DateTimeConst {
+    @JvmField
+    val FALLBACK: LocalDateTime = LocalDateTime.of(2000, 1, 1, 0, 0)
+}

--- a/src/main/java/jp/developer/bbee/pcassem/domain/gemini/GeminiServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/gemini/GeminiServiceImpl.java
@@ -25,8 +25,9 @@ public class GeminiServiceImpl implements GeminiService {
             var successData = new ReviewSuccess(successText);
             return new ReviewResponse(successData);
         } catch (Exception e) {
-            System.out.println("Error during Gemini API call: " + e.getMessage());
-            var failureData = new ReviewFailure(e.toString());
+            System.out.println("Error during Gemini API call: " + e);
+            var message = e.getMessage() != null ? e.getMessage() : "レビューの取得に失敗しました";
+            var failureData = new ReviewFailure(message);
             return new ReviewResponse(failureData);
         }
     }

--- a/src/main/java/jp/developer/bbee/pcassem/domain/gemini/GeminiServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/gemini/GeminiServiceImpl.java
@@ -26,7 +26,7 @@ public class GeminiServiceImpl implements GeminiService {
             return new ReviewResponse(successData);
         } catch (Exception e) {
             System.out.println("Error during Gemini API call: " + e.getMessage());
-            var failureData = new ReviewFailure(e.getMessage());
+            var failureData = new ReviewFailure(e.toString());
             return new ReviewResponse(failureData);
         }
     }

--- a/src/main/java/jp/developer/bbee/pcassem/model/SaveHead.java
+++ b/src/main/java/jp/developer/bbee/pcassem/model/SaveHead.java
@@ -1,6 +1,0 @@
-package jp.developer.bbee.pcassem.model;
-
-import java.time.LocalDateTime;
-
-public record SaveHead(String saveid, String guestid, String savename,
-                       LocalDateTime createddate, LocalDateTime lastupdate) {}

--- a/src/main/java/jp/developer/bbee/pcassem/model/SaveHead.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/model/SaveHead.kt
@@ -1,0 +1,12 @@
+package jp.developer.bbee.pcassem.model
+
+import java.time.LocalDateTime
+
+@JvmRecord
+data class SaveHead(
+    val saveid: String,
+    val guestid: String,
+    val savename: String,
+    val createddate: LocalDateTime,
+    val lastupdate: LocalDateTime,
+)

--- a/src/main/java/jp/developer/bbee/pcassem/model/UserAssem.java
+++ b/src/main/java/jp/developer/bbee/pcassem/model/UserAssem.java
@@ -1,6 +1,0 @@
-package jp.developer.bbee.pcassem.model;
-
-import java.time.LocalDateTime;
-
-public record UserAssem(String id, String deviceid, String device, String guestid,
-                        LocalDateTime createddate, LocalDateTime lastupdate) {}

--- a/src/main/java/jp/developer/bbee/pcassem/model/UserAssem.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/model/UserAssem.kt
@@ -1,0 +1,13 @@
+package jp.developer.bbee.pcassem.model
+
+import java.time.LocalDateTime
+
+@JvmRecord
+data class UserAssem(
+    val id: String,
+    val deviceid: String,
+    val device: String,
+    val guestid: String,
+    val createddate: LocalDateTime,
+    val lastupdate: LocalDateTime,
+)

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationResponse.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationResponse.java
@@ -1,3 +1,0 @@
-package jp.developer.bbee.pcassem.presentation.data;
-
-public record MigrationResponse(boolean success, String message) {}

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationResponse.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/MigrationResponse.kt
@@ -1,0 +1,3 @@
+package jp.developer.bbee.pcassem.presentation.data
+
+data class MigrationResponse(val success: Boolean, val message: String)

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewFailure.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewFailure.java
@@ -1,3 +1,0 @@
-package jp.developer.bbee.pcassem.presentation.data;
-
-public record ReviewFailure(String errorMessage) {}

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewFailure.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewFailure.kt
@@ -1,0 +1,3 @@
+package jp.developer.bbee.pcassem.presentation.data
+
+data class ReviewFailure(val errorMessage: String)

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewSuccess.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewSuccess.java
@@ -1,3 +1,0 @@
-package jp.developer.bbee.pcassem.presentation.data;
-
-public record ReviewSuccess(String reviewText) {}

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewSuccess.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/data/ReviewSuccess.kt
@@ -1,0 +1,3 @@
+package jp.developer.bbee.pcassem.presentation.data
+
+data class ReviewSuccess(val reviewText: String)


### PR DESCRIPTION
## Summary

- `pom.xml` に Kotlin サポートを追加（`kotlin-maven-plugin`, `kotlin-stdlib-jdk8`, `jackson-module-kotlin`, `kotlin-reflect`）
- 定数クラス（`ApiEndPoint`, `DateTimeConst`）を Kotlin `object` に変換
- モデル record（`UserAssem`, `SaveHead`）を `@JvmRecord data class` に変換（Java 側で `.deviceid()` 等のアクセサを使用しているため `@JvmRecord` で互換性を維持）
- presentation DTOs（`ReviewSuccess`, `ReviewFailure`, `MigrationResponse`）を `data class` に変換

## Test plan

- [ ] `./mvnw compile` が成功すること
- [ ] `./mvnw test` で全 26 件のテストが通ること（Failures: 0, Errors: 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)