### PR TITLE
refactor: reorganize packages into presentation/domain/data 3-layer structure

### DIFF
--- a/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
+++ b/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
@@ -1,6 +1,8 @@
-package jp.developer.bbee.pcassem;
+package jp.developer.bbee.pcassem.data.client;
 
-import jp.developer.bbee.pcassem.model.DeviceInfo;
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
+import jp.developer.bbee.pcassem.data.util.StringEncoder;
+import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
@@ -22,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static jp.developer.bbee.pcassem.HomeController.formatter;
+import static jp.developer.bbee.pcassem.presentation.controller.HomeController.formatter;
 
 public class KakakuClient {
     public static final boolean DEBUG = false;
@@ -78,7 +80,7 @@ public class KakakuClient {
     private final List<String> devices;
     private final Map<String, String> deviceUrl;
 
-    KakakuClient(DeviceInfoDao dao) {
+    public KakakuClient(DeviceInfoDao dao) {
         this.dao = dao;
 
         List<String> urlList = new ArrayList<>();

--- a/src/main/java/jp/developer/bbee/pcassem/data/dao/DeviceInfoDao.java
+++ b/src/main/java/jp/developer/bbee/pcassem/data/dao/DeviceInfoDao.java
@@ -1,10 +1,10 @@
-package jp.developer.bbee.pcassem;
+package jp.developer.bbee.pcassem.data.dao;
 
-import jp.developer.bbee.pcassem.HomeController.RestoreDevice;
-import jp.developer.bbee.pcassem.constants.DateTimeConst;
-import jp.developer.bbee.pcassem.model.DeviceInfo;
-import jp.developer.bbee.pcassem.model.SaveHead;
-import jp.developer.bbee.pcassem.model.UserAssem;
+import jp.developer.bbee.pcassem.presentation.controller.HomeController.RestoreDevice;
+import jp.developer.bbee.pcassem.domain.DateTimeConst;
+import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
+import jp.developer.bbee.pcassem.domain.model.SaveHead;
+import jp.developer.bbee.pcassem.domain.model.UserAssem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/src/main/java/jp/developer/bbee/pcassem/data/dao/UidMappingDao.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/data/dao/UidMappingDao.kt
@@ -1,4 +1,4 @@
-package jp.developer.bbee.pcassem
+package jp.developer.bbee.pcassem.data.dao
 
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service

--- a/src/main/java/jp/developer/bbee/pcassem/data/util/StringEncoder.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/data/util/StringEncoder.kt
@@ -1,6 +1,6 @@
 @file:JvmName("StringEncoder")
 
-package jp.developer.bbee.pcassem
+package jp.developer.bbee.pcassem.data.util
 
 import java.io.UnsupportedEncodingException
 import java.nio.charset.Charset

--- a/src/main/java/jp/developer/bbee/pcassem/domain/DateTimeConst.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/DateTimeConst.kt
@@ -1,4 +1,4 @@
-package jp.developer.bbee.pcassem.constants
+package jp.developer.bbee.pcassem.domain
 
 import java.time.LocalDateTime
 

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreService.kt
@@ -1,8 +1,8 @@
 package jp.developer.bbee.pcassem.domain.firestore
 
-import jp.developer.bbee.pcassem.DeviceInfoDao.SaveItem
-import jp.developer.bbee.pcassem.model.SaveHead
-import jp.developer.bbee.pcassem.model.UserAssem
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao.SaveItem
+import jp.developer.bbee.pcassem.domain.model.SaveHead
+import jp.developer.bbee.pcassem.domain.model.UserAssem
 import java.util.Optional
 
 interface FirestoreService {

--- a/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/firestore/FirestoreServiceImpl.java
@@ -5,10 +5,10 @@ import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.WriteBatch;
-import jp.developer.bbee.pcassem.DeviceInfoDao.SaveItem;
-import jp.developer.bbee.pcassem.constants.DateTimeConst;
-import jp.developer.bbee.pcassem.model.SaveHead;
-import jp.developer.bbee.pcassem.model.UserAssem;
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao.SaveItem;
+import jp.developer.bbee.pcassem.domain.DateTimeConst;
+import jp.developer.bbee.pcassem.domain.model.SaveHead;
+import jp.developer.bbee.pcassem.domain.model.UserAssem;
 import org.springframework.stereotype.Service;
 
 import java.time.ZoneId;

--- a/src/main/java/jp/developer/bbee/pcassem/domain/migration/MigrationServiceImpl.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/migration/MigrationServiceImpl.kt
@@ -1,7 +1,7 @@
 package jp.developer.bbee.pcassem.domain.migration
 
-import jp.developer.bbee.pcassem.DeviceInfoDao
-import jp.developer.bbee.pcassem.UidMappingDao
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao
+import jp.developer.bbee.pcassem.data.dao.UidMappingDao
 import jp.developer.bbee.pcassem.domain.auth.IdTokenVerifier
 import jp.developer.bbee.pcassem.domain.firestore.FirestoreService
 import org.slf4j.LoggerFactory

--- a/src/main/java/jp/developer/bbee/pcassem/domain/model/DeviceInfo.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/model/DeviceInfo.kt
@@ -1,4 +1,4 @@
-package jp.developer.bbee.pcassem.model
+package jp.developer.bbee.pcassem.domain.model
 
 import java.sql.Timestamp
 import java.time.LocalDateTime

--- a/src/main/java/jp/developer/bbee/pcassem/domain/model/SaveHead.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/model/SaveHead.kt
@@ -1,13 +1,12 @@
-package jp.developer.bbee.pcassem.model
+package jp.developer.bbee.pcassem.domain.model
 
 import java.time.LocalDateTime
 
 @JvmRecord
-data class UserAssem(
-    val id: String,
-    val deviceid: String,
-    val device: String,
+data class SaveHead(
+    val saveid: String,
     val guestid: String,
+    val savename: String,
     val createddate: LocalDateTime,
     val lastupdate: LocalDateTime,
 )

--- a/src/main/java/jp/developer/bbee/pcassem/domain/model/UserAssem.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/model/UserAssem.kt
@@ -1,12 +1,13 @@
-package jp.developer.bbee.pcassem.model
+package jp.developer.bbee.pcassem.domain.model
 
 import java.time.LocalDateTime
 
 @JvmRecord
-data class SaveHead(
-    val saveid: String,
+data class UserAssem(
+    val id: String,
+    val deviceid: String,
+    val device: String,
     val guestid: String,
-    val savename: String,
     val createddate: LocalDateTime,
     val lastupdate: LocalDateTime,
 )

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/ApiEndPoint.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/ApiEndPoint.kt
@@ -1,4 +1,4 @@
-package jp.developer.bbee.pcassem.constants
+package jp.developer.bbee.pcassem.presentation
 
 object ApiEndPoint {
     const val GET_DEVICE = "/devicelist"

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/ApiResponseController.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/ApiResponseController.kt
@@ -1,7 +1,8 @@
-package jp.developer.bbee.pcassem
+package jp.developer.bbee.pcassem.presentation.controller
 
-import jp.developer.bbee.pcassem.constants.ApiEndPoint
-import jp.developer.bbee.pcassem.model.DeviceInfo
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao
+import jp.developer.bbee.pcassem.domain.model.DeviceInfo
+import jp.developer.bbee.pcassem.presentation.ApiEndPoint
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
@@ -1,12 +1,14 @@
-package jp.developer.bbee.pcassem;
+package jp.developer.bbee.pcassem.presentation.controller;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
+import jp.developer.bbee.pcassem.data.client.KakakuClient;
 import jp.developer.bbee.pcassem.domain.firestore.FirestoreService;
-import jp.developer.bbee.pcassem.model.DeviceInfo;
-import jp.developer.bbee.pcassem.model.SaveHead;
-import jp.developer.bbee.pcassem.model.UserAssem;
+import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
+import jp.developer.bbee.pcassem.domain.model.SaveHead;
+import jp.developer.bbee.pcassem.domain.model.UserAssem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +62,7 @@ public class HomeController {
             );
 
     @Autowired // <- DAO auto setting
-    HomeController(DeviceInfoDao dao, FirestoreService firestoreService){
+    public HomeController(DeviceInfoDao dao, FirestoreService firestoreService){
         this.dao = dao;
         this.firestoreService = firestoreService;
         kakakuClient = new KakakuClient(dao);

--- a/src/test/java/jp/developer/bbee/pcassem/ApiResponseControllerTest.kt
+++ b/src/test/java/jp/developer/bbee/pcassem/ApiResponseControllerTest.kt
@@ -1,5 +1,7 @@
 package jp.developer.bbee.pcassem
 
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao
+import jp.developer.bbee.pcassem.presentation.controller.ApiResponseController
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -1,9 +1,11 @@
 package jp.developer.bbee.pcassem;
 
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
 import jp.developer.bbee.pcassem.domain.firestore.FirestoreService;
-import jp.developer.bbee.pcassem.model.DeviceInfo;
-import jp.developer.bbee.pcassem.model.SaveHead;
-import jp.developer.bbee.pcassem.model.UserAssem;
+import jp.developer.bbee.pcassem.presentation.controller.HomeController;
+import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
+import jp.developer.bbee.pcassem.domain.model.SaveHead;
+import jp.developer.bbee.pcassem.domain.model.UserAssem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +17,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import jp.developer.bbee.pcassem.DeviceInfoDao.SaveItem;
+import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao.SaveItem;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
## Summary

- **presentation**: コントローラー・DTO・APIエンドポイント定数を集約
- **domain**: ビジネスロジックのインターフェース・実装・モデル・定数を集約
- **data**: DAO・外部クライアント・ユーティリティを集約

### 移動ファイル

| ファイル | 旧パッケージ | 新パッケージ |
|---|---|---|
| `ApiResponseController` | root | `presentation.controller` |
| `HomeController` | root | `presentation.controller` |
| `ApiEndPoint` | `constants` | `presentation` |
| `DeviceInfo`, `SaveHead`, `UserAssem` | `model` | `domain.model` |
| `DateTimeConst` | `constants` | `domain` |
| `DeviceInfoDao`, `UidMappingDao` | root | `data.dao` |
| `KakakuClient` | root | `data.client` |
| `StringEncoder` | root | `data.util` |

### その他の変更

- 全ファイルの `package` 宣言と `import` を更新
- 異なるパッケージ間で参照されるコンストラクタ（`HomeController`, `KakakuClient`）を `public` に変更

## Test plan

- [x] `./mvnw clean test` — 全26件パス（Failures: 0, Errors: 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)