### PR TITLE
refactor: decouple HomeController from KakakuClient via PriceUpdateService

### DIFF
--- a/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
+++ b/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
@@ -19,6 +19,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,10 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static jp.developer.bbee.pcassem.presentation.controller.HomeController.formatter;
-
 @Service
 public class KakakuClient implements PriceUpdateService {
+    private static final DateTimeFormatter formatter =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd H:mm");
     public static final boolean DEBUG = false;
     public static final boolean DEBUG_FAST = false;
     public static final String KAKAKU_DOMAIN = "kakaku.com";

--- a/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
+++ b/src/main/java/jp/developer/bbee/pcassem/data/client/KakakuClient.java
@@ -3,6 +3,8 @@ package jp.developer.bbee.pcassem.data.client;
 import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
 import jp.developer.bbee.pcassem.data.util.StringEncoder;
 import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
+import jp.developer.bbee.pcassem.domain.PriceUpdateService;
+import org.springframework.stereotype.Service;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
@@ -26,7 +28,8 @@ import java.util.UUID;
 
 import static jp.developer.bbee.pcassem.presentation.controller.HomeController.formatter;
 
-public class KakakuClient {
+@Service
+public class KakakuClient implements PriceUpdateService {
     public static final boolean DEBUG = false;
     public static final boolean DEBUG_FAST = false;
     public static final String KAKAKU_DOMAIN = "kakaku.com";
@@ -76,7 +79,7 @@ public class KakakuClient {
     public static final int FLAG2_DIMM_DDR5 = 1 << 18;
     public static final int FLAG2_SODIMM = 1 << 23; // For determining DIMM(0) or SODIMM(1)
 
-    public boolean unAcquired;
+    private boolean unAcquired;
     private final List<String> devices;
     private final Map<String, String> deviceUrl;
 
@@ -112,6 +115,20 @@ public class KakakuClient {
             device = device.replaceAll("-", "");
             devices.add(device);
             deviceUrl.put(device, url);
+        }
+    }
+
+    @Override
+    public void prepare(boolean fullUpdate) {
+        this.unAcquired = fullUpdate;
+    }
+
+    @Override
+    public void execute() throws IOException {
+        if (unAcquired) {
+            getKakaku();
+        } else {
+            updateKakaku(false);
         }
     }
 

--- a/src/main/java/jp/developer/bbee/pcassem/domain/PriceUpdateService.kt
+++ b/src/main/java/jp/developer/bbee/pcassem/domain/PriceUpdateService.kt
@@ -1,0 +1,10 @@
+package jp.developer.bbee.pcassem.domain
+
+import java.io.IOException
+
+interface PriceUpdateService {
+    fun prepare(fullUpdate: Boolean)
+
+    @Throws(IOException::class)
+    fun execute()
+}

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
@@ -4,7 +4,7 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
-import jp.developer.bbee.pcassem.data.client.KakakuClient;
+import jp.developer.bbee.pcassem.domain.PriceUpdateService;
 import jp.developer.bbee.pcassem.domain.firestore.FirestoreService;
 import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
 import jp.developer.bbee.pcassem.domain.model.SaveHead;
@@ -50,7 +50,7 @@ public class HomeController {
     private static final int MAX_RETRY = 3;
     private final DeviceInfoDao dao;
     private final FirestoreService firestoreService;
-    private final KakakuClient kakakuClient;
+    private final PriceUpdateService priceUpdateService;
 
     private LocalDateTime fullUpdateDate = LocalDateTime.MIN;
 
@@ -62,10 +62,10 @@ public class HomeController {
             );
 
     @Autowired // <- DAO auto setting
-    public HomeController(DeviceInfoDao dao, FirestoreService firestoreService){
+    public HomeController(DeviceInfoDao dao, FirestoreService firestoreService, PriceUpdateService priceUpdateService){
         this.dao = dao;
         this.firestoreService = firestoreService;
-        kakakuClient = new KakakuClient(dao);
+        this.priceUpdateService = priceUpdateService;
         makeDeviceTypeJp();
     }
 
@@ -117,16 +117,12 @@ public class HomeController {
         boolean incomplete = true;
         boolean fullUpdate = (Duration.between(fullUpdateDate, LocalDateTime.now()).toHours() > 165); // 24*7=168
 //        fullUpdate = true; // debug
-        kakakuClient.unAcquired = fullUpdate;
+        priceUpdateService.prepare(fullUpdate);
 
         int loopCount = 0;
         while (incomplete && loopCount <= MAX_RETRY) {
             try {
-                if (kakakuClient.unAcquired && fullUpdate) {
-                    kakakuClient.getKakaku();
-                } else {
-                    kakakuClient.updateKakaku(false);
-                }
+                priceUpdateService.execute();
                 incomplete = false;
                 LocalDateTime lastUpdateDate = LocalDateTime.now();
                 if (fullUpdate) fullUpdateDate = lastUpdateDate;

--- a/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
+++ b/src/main/java/jp/developer/bbee/pcassem/presentation/controller/HomeController.java
@@ -61,7 +61,7 @@ public class HomeController {
             "ossoft", "lcdmonitor", "keyboard", "mouse", "dvddrive", "bluraydrive", "soundcard", "pcspeaker", "fancontroller", "casefan"
             );
 
-    @Autowired // <- DAO auto setting
+    @Autowired
     public HomeController(DeviceInfoDao dao, FirestoreService firestoreService, PriceUpdateService priceUpdateService){
         this.dao = dao;
         this.firestoreService = firestoreService;

--- a/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
+++ b/src/test/java/jp/developer/bbee/pcassem/HomeControllerTest.java
@@ -2,6 +2,7 @@ package jp.developer.bbee.pcassem;
 
 import jp.developer.bbee.pcassem.data.dao.DeviceInfoDao;
 import jp.developer.bbee.pcassem.domain.firestore.FirestoreService;
+import jp.developer.bbee.pcassem.domain.PriceUpdateService;
 import jp.developer.bbee.pcassem.presentation.controller.HomeController;
 import jp.developer.bbee.pcassem.domain.model.DeviceInfo;
 import jp.developer.bbee.pcassem.domain.model.SaveHead;
@@ -39,6 +40,9 @@ class HomeControllerTest {
     @Mock
     private FirestoreService firestoreService;
 
+    @Mock
+    private PriceUpdateService priceUpdateService;
+
     private MockMvc mockMvc;
 
     private static final String FIREBASE_UID = "firebase-uid-12345";
@@ -49,7 +53,7 @@ class HomeControllerTest {
         when(dao.findRecordByIds(anyList())).thenReturn(Collections.emptyList());
         when(dao.getSaveItemsBySaveId(anyString())).thenReturn(Collections.emptyList());
 
-        HomeController controller = new HomeController(dao, firestoreService);
+        HomeController controller = new HomeController(dao, firestoreService, priceUpdateService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 


### PR DESCRIPTION
## Summary

- `HomeController`（presentation層）が `KakakuClient`（data層）に直接依存していたのを解消
- `domain/PriceUpdateService` インターフェースを新設し、`HomeController` はこれに依存
- `KakakuClient` が `PriceUpdateService` を実装し `@Service` で Spring 管理に

### 変更内容

| ファイル | 変更 |
|---|---|
| `domain/PriceUpdateService.kt` | 新規作成。`prepare(fullUpdate)` / `execute()` を定義 |
| `data/client/KakakuClient.java` | `@Service` 追加、`PriceUpdateService` 実装。`unAcquired` を private 化 |
| `presentation/controller/HomeController.java` | `KakakuClient` フィールド → `PriceUpdateService` インジェクション。`new KakakuClient(dao)` を削除 |
| `HomeControllerTest.java` | `PriceUpdateService` のモックを追加 |

### 動作の変化なし

- `KakakuClient.execute()` 内部で `getKakaku()` / `updateKakaku(false)` の選択ロジックを保持
- `prepare(fullUpdate)` が旧来の `unAcquired = fullUpdate` に相当
- リトライ時の状態遷移も `unAcquired` フィールドで従来通り維持

## Test plan

- [x] `./mvnw clean test` — 全26件パス（Failures: 0, Errors: 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)